### PR TITLE
(FM-2576) - Found a bug in the way we added meta parameters to the command line

### DIFF
--- a/lib/puppet/provider/sqlserver_instance/mssql.rb
+++ b/lib/puppet/provider/sqlserver_instance/mssql.rb
@@ -133,6 +133,13 @@ may be overridden by some command line arguments")
           cmd_args << "/SQLSYSADMINACCOUNTS=\"#{@resource[:sql_sysadmin_accounts]}\""
         end
       end
+      if not_nil_and_not_empty? @resource[:as_sysadmin_accounts]
+        if @resource[:as_sysadmin_accounts].kind_of?(Array)
+          cmd_args << "/ASSYSADMINACCOUNTS=#{ Array.new(@resource[:as_sysadmin_accounts]).collect { |account| "\"#{account}\"" }.join(' ')}"
+        else
+          cmd_args << "/ASSYSADMINACCOUNTS=\"#{@resource[:as_sysadmin_accounts]}\""
+        end
+      end
     end
     cmd_args
   end


### PR DESCRIPTION
If any metaparameters were used we added them as well which causes install to fail
i.e. /Require=Class['sqlserver'] will be added during sql install if exists on the defined type
