### PR TITLE
(maint) fix module installation

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -39,7 +39,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
 
   agents.each do |agent|
     step "Install sqlserver module to agent #{agent.node_name}"
-    result = on agent, "echo #{default['distmoduledir']}"
+    result = on agent, "echo #{agent['distmoduledir']}"
     target = result.raw_output.chomp
     proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
     exec_puppet = <<-EOS


### PR DESCRIPTION
- In 7ec8cda6cbe5fb035105e0ec8f5cb3d059413f96 a change was
  introduced that removed the 'default' node and provided a sql_host
  role for agent nodes.
  
  With the removal of the 'default' node, some code relying upon
  that role was broken, and modules installs failed to complete.
