### PR TITLE
(maint) Inject CommonProgramFiles env var

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -38,6 +38,10 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   end
 
   agents.each do |agent|
+    step "Emit CommonProgramFiles environment variable"
+    program_files = agent.get_env_var('ProgramFiles').split('=')[1]
+    agent.add_env_var('CommonProgramFiles', "#{program_files}\\Common Files")
+
     step "Install sqlserver module to agent #{agent.node_name}"
     result = on agent, "echo #{agent['distmoduledir']}"
     target = result.raw_output.chomp


### PR DESCRIPTION
- Cygwin environments notably omit a number of important Windows
  environment variables including:
  
  APPDATA
  CommonProgramFiles
  CommonProgramFiles(x86)
  LOCALAPPDATA
  ProgramData
  ProgramFiles(x86)
  ProgramW6432
  PSModulePath
- When using the ADODB.Connection COM object, the provider from
  the Connection String (in our case SQLOLEDB.1) is a ProgID
  that references another COM component for the implementation
  of connection library to SQL Server.  Standard COM library
  resolution procedures apply when finding the DLL on disk to
  load.  In the registry, the path to the InProcServer32 used
  for the library is listed as:
  
  %CommonProgramFiles%\System\Ole DB\sqloledb.dll
  
  Since the key is a REG_EXPAND_SZ, normal rules about env var
  expansion apply here.
  
  Interestingly, when running under a default Cygwin SSH session,
  since %CommonProgramFiles% is not captured in the environment,
  COM fails to load sqloledb.dll and the failure is propagated
  during the .Open("Provider=SQLOLEDB.1; ... ") call.
  
  Fix this issue by capturing the hosts %ProgramFiles% environment
  variable and appending "\Common Files" to it, which is how
  the pathing structure has always been.
  
  The solution here is a bit hacky.  It would be better to
  launch a process that doesn't capture the Cygwin environment,
  echo the %CommonProgramFiles% environment variable and then
  inject that into our SSH session.
