### PR TITLE
(maint) remove unneeded pre-suite module installs

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -53,7 +53,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     }
     EOS
     apply_manifest_on(agent, exec_puppet)
-    %w(puppetlabs/stdlib puppetlabs/acl cyberious/pget puppetlabs/reboot puppetlabs/registry).each do |dep|
+    %w(puppetlabs/stdlib cyberious/pget).each do |dep|
       on agent, puppet("module install #{dep}")
     end
     on agent, "git clone https://github.com/puppetlabs/puppetlabs-mount_iso #{target}/mount_iso"


### PR DESCRIPTION
- ACL, reboot and registry modules are not needed for testing, or
  as a dependency for this module, so don't install them.
