### PR TITLE
(maint) replaced debian6 by centos7 master in nodesets yml files

### DIFF
--- a/spec/acceptance/nodesets/win_2012_sql2012.yml
+++ b/spec/acceptance/nodesets/win_2012_sql2012.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012:
     roles:

--- a/spec/acceptance/nodesets/win_2012_sql2012_future.yml
+++ b/spec/acceptance/nodesets/win_2012_sql2012_future.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012:
     roles:

--- a/spec/acceptance/nodesets/win_2012_sql2014.yml
+++ b/spec/acceptance/nodesets/win_2012_sql2014.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012:
     roles:

--- a/spec/acceptance/nodesets/win_2012_sql2014_future.yml
+++ b/spec/acceptance/nodesets/win_2012_sql2014_future.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012:
     roles:

--- a/spec/acceptance/nodesets/win_2012r2_sql2012.yml
+++ b/spec/acceptance/nodesets/win_2012r2_sql2012.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012r2:
     roles:

--- a/spec/acceptance/nodesets/win_2012r2_sql2012_future.yml
+++ b/spec/acceptance/nodesets/win_2012r2_sql2012_future.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012r2:
     roles:

--- a/spec/acceptance/nodesets/win_2012r2_sql2014.yml
+++ b/spec/acceptance/nodesets/win_2012r2_sql2014.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012r2:
     roles:

--- a/spec/acceptance/nodesets/win_2012r2_sql2014_future.yml
+++ b/spec/acceptance/nodesets/win_2012r2_sql2014_future.yml
@@ -1,11 +1,11 @@
 HOSTS:
-  debian6:
+  centos7-master:
     roles:
       - master
       - database
       - dashboard
-    platform: debian-6-i386
-    template: debian-6-i386
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     hypervisor: vcloud
   win2012r2:
     roles:


### PR DESCRIPTION
Debian is no longer supported for master from Shallow Gravy. This PR replaced debian6 by Centos7 for master node in Nodesets yml files.
