### PR TITLE
(DO NOT MERGE)(MODULES-2312) Use sp_executesql to execute T-SQL

### DIFF
--- a/lib/puppet/property/sqlserver_tsql.rb
+++ b/lib/puppet/property/sqlserver_tsql.rb
@@ -3,9 +3,12 @@ require 'puppet/property'
 class Puppet::Property::SqlserverTsql < Puppet::Property
   desc 'TSQL property that we are going to wrap with a try catch'
   munge do |value|
+    quoted_value = value.gsub('\'', '\'\'')
     erb_template = <<-TEMPLATE
 BEGIN TRY
-    #{value}
+    DECLARE @sql_text as NVARCHAR(max);
+    SET @sql_text = N'#{quoted_value}'
+    EXECUTE sp_executesql @sql_text;
 END TRY
 BEGIN CATCH
     DECLARE @msg as VARCHAR(max);

--- a/spec/unit/puppet/property/tsql_spec.rb
+++ b/spec/unit/puppet/property/tsql_spec.rb
@@ -14,8 +14,13 @@ describe 'tsql' do
   it 'should munge value to have begin and end try' do
     @node[:command] = 'function foo'
     @node[:onlyif] = 'exec bar'
-    expect(@node[:onlyif]).to match(/BEGIN TRY\n\s+exec bar\nEND TRY/)
-    expect(@node[:command]).to match(/BEGIN TRY\n\s+function foo\nEND TRY/)
+    expect(@node[:onlyif]).to match(/BEGIN TRY\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'exec bar'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY/)
+    expect(@node[:command]).to match(/BEGIN TRY\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'function foo'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY/)
+  end
+
+  it 'should properly escape single quotes in queries' do
+    @node[:command] = 'SELECT \'FOO\''
+    expect(@node[:command]).to match(/SET @sql_text = N'SELECT \'\'FOO\'\'/)
   end
 
 end

--- a/spec/unit/puppet/provider/sqlserver__tsql_spec.rb
+++ b/spec/unit/puppet/provider/sqlserver__tsql_spec.rb
@@ -22,9 +22,12 @@ RSpec.describe Puppet::Type.type(:sqlserver_tsql).provider(:mssql) do
   end
 
   def gen_query(query)
+    quoted_query = query.gsub('\'', '\'\'')
     <<-PP
 BEGIN TRY
-    #{query}
+    DECLARE @sql_text as NVARCHAR(max);
+    SET @sql_text = N'#{quoted_query}'
+    EXECUTE sp_executesql @sql_text;
 END TRY
 BEGIN CATCH
     DECLARE @msg as VARCHAR(max);


### PR DESCRIPTION
- Previously, the SQL server module executed arbitrary TSQL by
  injecting user supplied data into a template verbatim.  Unfortunately
  this mechanism does nothing to address syntax errors, which will
  prevent the try / catch mechanism employed from working and
  propagating errors.
  
  The stored procedure sp_executesql can be used to execute arbitrary
  SQL strings, and will properly propagate an exception that can be
  caught, so use that method.
  
  Of note, since the user query is being placed into a string, it must
  have single quotes escaped properly. An additional test has been
  added to verify that single quotes are escaped as expected.
