### PR TITLE
(FM-3252) CI Pipeline for sqlserver at step 7a

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 
 group :system_tests do
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.19')
   gem 'beaker-puppet_install_helper',  :require => false
 end
 


### PR DESCRIPTION
In the current Gemfile, beaker is set ~> 2.18 so it will install beaker 2.18.2, this old version of beaker has known issue of unable to find the correct path to windows msi agent file. Beaker 2.18.3 and up will fix the problem.

This PR just simply replaces old beaker 2.18 by newly release 2.19 beaker.
