### PR TITLE
(maint) Guarantee Facter version for old Puppets / (MODULES-2452) Update Beaker Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 
 group :system_tests do
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'beaker-puppet_install_helper',  :require => false
 end
 


### PR DESCRIPTION
For Puppet older than 3.5.0 on Windows, a facter version at or under
1.7.5 should be selected for greatest compatibility when requesting
a gem puppet version and if a facter version has not been specified.

Update the Beaker version to use "2.20" which has an important fix for PE
installations.
