### PR TITLE
(FM-3655) SQL Server CI acceptance issues

### DIFF
--- a/spec/acceptance/sqlserver_config_spec.rb
+++ b/spec/acceptance/sqlserver_config_spec.rb
@@ -5,17 +5,16 @@ require 'erb'
 host = find_only_one("sql_host")
 
 # Get instance name
-INST_NAME = ("MSSQL" + SecureRandom.hex(4)).upcase
+inst_name = ("MSSQL" + SecureRandom.hex(4)).upcase
 
 # Get database name
-DB_NAME   = ("DB" + SecureRandom.hex(4)).upcase
+db_name   = ("DB" + SecureRandom.hex(4)).upcase
 
 describe "sqlserver::config test", :node => host do
-  version = host['sql_version'].to_s
 
-  def ensure_sqlserver_instance(host, ensure_val = 'present')
+  def ensure_sqlserver_instance(host,inst_name, ensure_val = 'present')
     create_new_instance= <<-MANIFEST
-      sqlserver_instance{'#{INST_NAME}':
+      sqlserver_instance{'#{inst_name}':
       ensure                => '#{ensure_val}',
       source                => 'H:',
       features              => [ 'SQL' ],
@@ -34,7 +33,7 @@ describe "sqlserver::config test", :node => host do
 
     before(:all) do
       # Create new instance
-      ensure_sqlserver_instance(host)
+      ensure_sqlserver_instance(host, inst_name)
 
       # get credentials for new config
       @admin_user = "admin" + SecureRandom.hex(2)
@@ -51,13 +50,13 @@ describe "sqlserver::config test", :node => host do
 
     it "Create New Admin Login:" do
       create_new_login = <<-MANIFEST
-      sqlserver::config{'#{INST_NAME}':
-        instance_name => '#{INST_NAME}',
+      sqlserver::config{'#{inst_name}':
+        instance_name => '#{inst_name}',
         admin_user    => 'sa',
         admin_pass    => 'Pupp3t1@',
       }
       sqlserver::login{'#{@admin_user}':
-        instance    => '#{INST_NAME}',
+        instance    => '#{inst_name}',
         login_type  => 'SQL_LOGIN',
         login       => '#{@admin_user}',
         password    => '#{@admin_pass}',
@@ -71,13 +70,13 @@ describe "sqlserver::config test", :node => host do
 
     it "Validate New Config WITH using instance_name in sqlserver::config" do
       pp = <<-MANIFEST
-      sqlserver::config{'#{INST_NAME}':
+      sqlserver::config{'#{inst_name}':
         admin_user    => '#{@admin_user}',
         admin_pass    => '#{@admin_pass}',
-        instance_name => '#{INST_NAME}',
+        instance_name => '#{inst_name}',
       }
-      sqlserver::database{'#{DB_NAME}':
-        instance => '#{INST_NAME}',
+      sqlserver::database{'#{db_name}':
+        instance => '#{inst_name}',
       }
       MANIFEST
       apply_manifest_on(host, pp) do |r|
@@ -87,20 +86,20 @@ describe "sqlserver::config test", :node => host do
 
     it "Validate new login and database actualy created" do
       hostname = host.hostname
-      query = "USE #{DB_NAME}; SELECT * from master..sysdatabases WHERE name = '#{DB_NAME}'"
+      query = "USE #{db_name}; SELECT * from master..sysdatabases WHERE name = '#{db_name}'"
 
-      run_sql_query(host, {:query => query, :server => hostname, :instance => INST_NAME, \
+      run_sql_query(host, {:query => query, :server => hostname, :instance => inst_name, \
       :sql_admin_user => @admin_user, :sql_admin_pass => @admin_pass, :expected_row_count => 1})
     end
 
     it "Validate New Config WITHOUT using instance_name in sqlserver::config" do
       pp = <<-MANIFEST
-      sqlserver::config{'#{INST_NAME}':
+      sqlserver::config{'#{inst_name}':
         admin_user    => '#{@admin_user}',
         admin_pass    => '#{@admin_pass}',
       }
-      sqlserver::database{'#{DB_NAME}':
-        instance => '#{INST_NAME}',
+      sqlserver::database{'#{db_name}':
+        instance => '#{inst_name}',
       }
       MANIFEST
       apply_manifest_on(host, pp) do |r|
@@ -110,12 +109,12 @@ describe "sqlserver::config test", :node => host do
 
     it "Negative test: sqlserver::config without admin_user" do
       pp = <<-MANIFEST
-      sqlserver::config{'#{INST_NAME}':
+      sqlserver::config{'#{inst_name}':
           admin_pass    => '#{@admin_pass}',
-          instance_name => '#{INST_NAME}',
+          instance_name => '#{inst_name}',
       }
-      sqlserver::database{'#{DB_NAME}':
-          instance => '#{INST_NAME}',
+      sqlserver::database{'#{db_name}':
+          instance => '#{inst_name}',
       }
       MANIFEST
       apply_manifest_on(host, pp, {:acceptable_exit_codes => [0,1]}) do |r|
@@ -125,12 +124,12 @@ describe "sqlserver::config test", :node => host do
 
     it "Negative test: sqlserver::config without admin_pass" do
       pp = <<-MANIFEST
-      sqlserver::config{'#{INST_NAME}':
+      sqlserver::config{'#{inst_name}':
           admin_user    => '#{@admin_user}',
-          instance_name => '#{INST_NAME}',
+          instance_name => '#{inst_name}',
       }
-      sqlserver::database{'#{DB_NAME}':
-          instance => '#{INST_NAME}',
+      sqlserver::database{'#{db_name}':
+          instance => '#{inst_name}',
       }
       MANIFEST
       apply_manifest_on(host, pp, {:acceptable_exit_codes => [0,1]}) do |r|

--- a/spec/acceptance/sqlserver_tsql_spec.rb
+++ b/spec/acceptance/sqlserver_tsql_spec.rb
@@ -5,20 +5,20 @@ require 'erb'
 host = find_only_one("sql_host")
 
 # database name
-DB_NAME   = ("DB" + SecureRandom.hex(4)).upcase
+db_name   = ("DB" + SecureRandom.hex(4)).upcase
 
 #database user:
 DB_LOGIN_USER   = "loginuser" + SecureRandom.hex(2)
 
 describe "sqlserver_tsql test", :node => host do
 
-  def ensure_sqlserver_database(host, ensure_val = 'present')
+  def ensure_sqlserver_database(host,db_name, ensure_val = 'present')
     pp = <<-MANIFEST
     sqlserver::config{'MSSQLSERVER':
       admin_user   => 'sa',
       admin_pass   => 'Pupp3t1@',
     }
-    sqlserver::database{'#{DB_NAME}':
+    sqlserver::database{'#{db_name}':
         instance => 'MSSQLSERVER',
     }
     MANIFEST
@@ -33,9 +33,9 @@ describe "sqlserver_tsql test", :node => host do
     before(:all) do
       # Create new database
       @table_name = 'Tables_' + SecureRandom.hex(3)
-      @query = "USE #{DB_NAME}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
+      @query = "USE #{db_name}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
 
-      ensure_sqlserver_database(host)
+      ensure_sqlserver_database(host, db_name)
     end
 
     after(:all) do
@@ -52,7 +52,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       sqlserver_tsql{'testsqlserver_tsql':
         instance => 'MSSQLSERVER',
-        database => '#{DB_NAME}',
+        database => '#{db_name}',
         command => "CREATE TABLE #{@table_name} (id INT, name VARCHAR(20), email VARCHAR(20));",
       }
       MANIFEST
@@ -73,7 +73,7 @@ describe "sqlserver_tsql test", :node => host do
     it "Run sqlserver_tsql WITH onlyif is true:" do
       #Initilize a new table name:
       @table_name = 'Table_' + SecureRandom.hex(3)
-      @query = "USE #{DB_NAME}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
+      @query = "USE #{db_name}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
       pp = <<-MANIFEST
       sqlserver::config{'MSSQLSERVER':
           instance_name => 'MSSQLSERVER',
@@ -82,7 +82,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       sqlserver_tsql{'testsqlserver_tsql':
           instance => 'MSSQLSERVER',
-          database => '#{DB_NAME}',
+          database => '#{db_name}',
           command => "CREATE TABLE #{@table_name} (id INT, name VARCHAR(20), email VARCHAR(20));",
           onlyif => "IF (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES) < 10000"
       }
@@ -105,7 +105,7 @@ describe "sqlserver_tsql test", :node => host do
     it "Run sqlserver_tsql WITH onlyif is false:" do
       #Initilize a new table name:
       @table_name = 'Table_' + SecureRandom.hex(3)
-      @query = "USE #{DB_NAME}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
+      @query = "USE #{db_name}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
       pp = <<-MANIFEST
       sqlserver::config{'MSSQLSERVER':
           instance_name => 'MSSQLSERVER',
@@ -114,7 +114,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       sqlserver_tsql{'testsqlserver_tsql':
           instance => 'MSSQLSERVER',
-          database => '#{DB_NAME}',
+          database => '#{db_name}',
           command => "CREATE TABLE #{@table_name} (id INT, name VARCHAR(20), email VARCHAR(20));",
           onlyif => "IF (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES) > 10000
           THROW 5300, 'Too many tables', 10"
@@ -144,7 +144,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       sqlserver_tsql{'testsqlserver_tsql':
         instance => 'MSSQLSERVER',
-        database => '#{DB_NAME}',
+        database => '#{db_name}',
         command => "invalid-tsql-command",
       }
       MANIFEST


### PR DESCRIPTION
Before this PR, database name is a constant value and with the pending issue of unable to delete database (ticket MODULES-2554), only one database has been used in several tests. This cause the test CI failed.

This PR removes all constants and replaced them by variables, commenting out dead codes, and temporarily skip delete/absent database in each test script (because of MODULES-2554 as mentioned above)
