### PR TITLE
(FM-3706)Create database with optional compatibility breaks CI

### DIFF
--- a/spec/acceptance/sqlserver_database_spec.rb
+++ b/spec/acceptance/sqlserver_database_spec.rb
@@ -105,7 +105,7 @@ describe "Test sqlserver::database", :node => host do
           admin_pass    => 'Pupp3t1@',
         }
         sqlserver::database{'#{@db_name}':
-          compatibility => 120,
+          compatibility => 100,
         }
         sqlserver_tsql{'testsqlserver_tsql':
           instance => 'MSSQLSERVER',
@@ -124,7 +124,7 @@ describe "Test sqlserver::database", :node => host do
       query = "SELECT name AS Database_Name, compatibility_level
                 FROM sys.databases
                 WHERE name = '#{@db_name}'
-                AND compatibility_level = '120';"
+                AND compatibility_level = '100';"
 
       run_sql_query(host, run_sql_query_opts(query, 1))
     end


### PR DESCRIPTION
Before this PR, the test case was creating a database with compatibility_level is 120 which only applies to SQL Server 2014 to SQL Server 2016, so the test case failed when being tested against SQL Server 2012.

This PR changes the compatibility level to 100, this level applies to SQL Server 2008 to SQL Server 2016
