### PR TITLE
(FM-5080) add Puppet version ranges

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,10 @@
     {
       "name": "pe",
       "version_requirement": ">= 3.7.0 < 2015.4.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=3.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
In addition to PE metadata, add Puppet metadata to be used
for determining compatibility with Puppet versions.
