### PR TITLE
(FM-5055) Pin rspec-puppet to 2.3.2 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ group :development do
   gem 'pry',                                 :require => false
   gem 'simplecov',                           :require => false
   gem 'yard',                                :require => false
+  # rspec-puppet should be pinned to 2.3.2 until MODULES-3240 is resolved
+  gem 'rspec-puppet','2.3.2',                :require => false  
 end
 
 group :system_tests do


### PR DESCRIPTION
During CI Triage, the SQL Server pipeline was failing due to rspec-puppet
changing from version 2.3.2 to 2.4.0.  This commit pins rspec-puppet to
2.3.2 until the incompatibility is resolved in MODULES-3240.
