### PR TITLE
(MODULES-3240) Fix rspec-puppet incompatibility

### DIFF
--- a/spec/functions/functions_shared_examples.rb
+++ b/spec/functions/functions_shared_examples.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'rspec'
 
 RSpec.shared_context 'scope' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 end
 
 RSpec.shared_examples 'compile' do

--- a/spec/functions/sqlserver_is_domain_user_spec.rb
+++ b/spec/functions/sqlserver_is_domain_user_spec.rb
@@ -2,7 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib/pupp
 
 RSpec.describe 'sqlserver_is_domain_or_local_user?' do
   shared_examples 'return the value' do
-    let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
     it {
       Facter.stubs(:value).with(anything())
       Facter.stubs(:value).with(:hostname).returns('mybox')

--- a/spec/functions/sqlserver_upcase_spec.rb
+++ b/spec/functions/sqlserver_upcase_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe "the sqlserver_upcase function" do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it "should exist" do
     expect(Puppet::Parser::Functions.function("sqlserver_upcase")).to eq("function_sqlserver_upcase")
   end

--- a/spec/functions/sqlserver_validate_hash_uniq_values_spec.rb
+++ b/spec/functions/sqlserver_validate_hash_uniq_values_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe "the sqlserver_validate_hash_uniq_values" do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it "should exist" do
     expect(Puppet::Parser::Functions.function("sqlserver_validate_hash_uniq_values")).to eq("function_sqlserver_validate_hash_uniq_values")
   end

--- a/spec/functions/sqlserver_validate_instance_name_spec.rb
+++ b/spec/functions/sqlserver_validate_instance_name_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'sqlserver_validate_instance_name function' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it 'should exist' do
     expect(Puppet::Parser::Functions.function("sqlserver_validate_instance_name")).to eq("function_sqlserver_validate_instance_name")
   end

--- a/spec/functions/sqlserver_validate_size_spec.rb
+++ b/spec/functions/sqlserver_validate_size_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'puppet/error'
 
 describe 'sqlserver_validate_size function' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   shared_examples 'should compile' do |value|
     it "with a value #{value}" do
       scope.function_sqlserver_validate_size([value])

--- a/spec/functions/sqlserver_validate_svrroles_hash_spec.rb
+++ b/spec/functions/sqlserver_validate_svrroles_hash_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'puppet/error'
 
 RSpec.describe 'sqlserver_validate_svrroles_hash function' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   possible_roles = %w(sysadmin serveradmin securityadmin processadmin setupadmin bulkadmin diskadmin dbcreator)
 
   shared_examples 'compile' do |value|


### PR DESCRIPTION
Removed creating the 'scope' variable as it is already available via rspec-puppet.  Without removing this statement, unit tests will fail on rspec-puppet 2.4.0, and probably subsequent versions as well.
