### PR TITLE
(MODULES-3355) Fix Role Name Collisions

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -62,7 +62,7 @@ define sqlserver::role(
     absent  => 'delete',
   }
 
-  sqlserver_tsql{ "role-${role}-${instance}":
+  sqlserver_tsql{ "role-${instance}-${database}-${role}":
     command  => template("sqlserver/${_create_delete}/role.sql.erb"),
     onlyif   => template('sqlserver/query/role_exists.sql.erb'),
     instance => $instance,

--- a/spec/defines/role_spec.rb
+++ b/spec/defines/role_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'manifest_shared_exam
 
 RSpec.describe 'sqlserver::role', :type => :define do
   include_context 'manifests' do
-    let(:sqlserver_tsql_title) { 'role-myCustomRole-MSSQLSERVER' }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-master-myCustomRole' }
     let(:title) { 'myCustomRole' }
   end
 
@@ -54,6 +54,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
     let(:additional_params) { {
       'database' => 'myCrazyDb',
     } }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-myCrazyDb-myCustomRole' }
     describe 'with server role type' do
       let(:raise_error_check) { 'Can not specify a database other than master when managing SERVER ROLES' }
       it_behaves_like 'validation error'
@@ -74,7 +75,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
     describe 'non default instance' do
       let(:params) { {:instance => 'MYCUSTOM'} }
       it {
-        should contain_sqlserver_tsql('role-myCustomRole-MYCUSTOM').with_instance('MYCUSTOM')
+        should contain_sqlserver_tsql('role-MYCUSTOM-master-myCustomRole').with_instance('MYCUSTOM')
       }
     end
     describe 'empty instance' do


### PR DESCRIPTION
If sqlserver::role is specified more than one for the same role
non-unique titles will be generated for the sqlserver_tsql that
will handle the operations. This is likely to happen if setting
up heira configs like this:

'sqlserver::role':
  ‘User_1’:
    role: db_owner
    database: FooBar
    instance: MSSQLSERVER
    members:
      - ‘User_1’
    type: 'DATABASE'
  ‘User_2’:
    role: db_owner
    database: Wakka
    instance: MSSQLSERVER
    members:
      - ‘User_2’
    type: 'DATABASE'
