### PR TITLE
Adding more advanced example for SQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sqlserver_instance{'MSSQLSERVER':
 }
 ~~~
 
-This example creates the same MS SQL instance as above with additional options, including security mode (requiring password to be set) and optional install switches.
+This example creates the same MS SQL instance as shown above with additional options: security mode (requiring password to be set) and other optional install switches. This is specified using a hash syntax.
 
 ##Usage
 


### PR DESCRIPTION
Adding a more advanced example for SQL Server that illustrates the use
of both security_mode and install_switches. The instance requires a
hash which may be unfamiliar to admins.
