### PR TITLE
(PE-16132) Add Windows Based Authentication for sqlserver::config

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,9 +286,19 @@ Requires the `sqlserver::config` define for access to the parent instance.
 
 Stores credentials for Puppet to use when managing a given SQL Server instance.
 
-* `admin_pass`: *Required.* Supplies the password for the specified `admin_user` account. Valid options: a string containing a valid password.
+* `admin_login_type`: *Optional.* Specifies the type of login used to manage to SQL Server instace. The login type affects the `admin_user` and admin_pass` parameters which are described below. Valid options: 'SQL_LOGIN' and 'WINDOWS_LOGIN'. Default: 'SQL_LOGIN'.
 
-* `admin_user`: *Required.* Specifies a login account with sysadmin rights on the server, to be used for managing the instance. Valid options: a string containing a username.
+- When using SQL Server based authentication - `SQL_LOGIN`
+
+    * `admin_pass`: *Required.* Supplies the password for the specified `admin_user` account. Valid options: a string containing a valid password.
+
+    * `admin_user`: *Required.* Specifies a login account with sysadmin rights on the server, to be used for managing the instance. Valid options: a string containing a username.
+
+- When using Windows based authentication - `WINDOWS_LOGIN`
+
+    * `admin_pass`: *Optional.* Valid options: undefined or an empty string `''`
+
+    * `admin_user`: *Optional.* Valid options: undefined or an empty string `''`
 
 * `instance_name`: *Optional.* Specifies a SQL Server instance to manage. Valid options: a string containing the name of an existing instance. Default: the title of your declared resource.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,9 +8,13 @@
 # [instance_name]
 #   The instance name you want to manage.  Defaults to the $title when not defined explicitly.
 # [admin_user]
-#   A user/login who has sysadmin rights on the server, preferably a SQL_Login type
+#   Only required for SQL_LOGIN type. A user/login who has sysadmin rights on the server
 # [admin_pass]
-#   The password in order to access the server to be managed.
+#   Only required for SQL_LOGIN type. The password in order to access the server to be managed.
+# [admin_login_type]
+#   The type of account use to configure the server.  Valid values are SQL_LOGIN and WINDOWS_LOGIN, with a default of SQL_LOGIN
+#   The SQL_LOGIN requires the admin_user and admin_pass to be set
+#   The WINDOWS_LOGIN requires the adm_user and admin_pass to be empty or undefined
 #
 # @example
 #   sqlserver::config{'MSSQLSERVER':
@@ -19,10 +23,23 @@
 #   }
 #
 define sqlserver::config (
-  $admin_user,
-  $admin_pass,
+  $admin_user    = '',
+  $admin_pass    = '',
+  $admin_login_type    = 'SQL_LOGIN',
   $instance_name = $title,
 ) {
-  ##This config is a catalog requirement for sqlserver_tsql and is looked up to retrieve the admin_user and
-  ## admin_pass for a given instance_name
+  ##This config is a catalog requirement for sqlserver_tsql and is looked up to retrieve the admin_user,
+  ## admin_pass and admin_login_type for a given instance_name
+
+  case $admin_login_type {
+    'SQL_LOGIN': {
+      if ($admin_user == '') { fail 'sqlserver::config expects admin_user to be set for a admin_login_type of SQL_LOGIN' }
+      if ($admin_pass == '') { fail 'sqlserver::config expects admin_pass to be set for a admin_login_type of SQL_LOGIN' }
+    }
+    'WINDOWS_LOGIN': {
+      if ($admin_user != '') { fail 'sqlserver::config expects admin_user to be empty for a admin_login_type of WINDOWS_LOGIN' }
+      if ($admin_pass != '') { fail 'sqlserver::config expects admin_pass to be empty for a admin_login_type of WINDOWS_LOGIN' }
+    }
+    default: { fail "sqlserver::config expects a admin_login_type of SQL_LOGIN or WINDOWS_LOGIN but found ${admin_login_type}" }
+  }
 }

--- a/spec/acceptance/sqlserver_tsql_spec.rb
+++ b/spec/acceptance/sqlserver_tsql_spec.rb
@@ -28,7 +28,49 @@ describe "sqlserver_tsql test", :node => host do
     end
   end
 
-  context "Test sqlserver_tsql", {:testrail => ['89024', '89025', '89026', '89068', '89069']} do
+  context "Test sqlserver_tsql with Windows based authentication"  do
+
+    before(:all) do
+      # Create new database
+      @table_name = 'Tables_' + SecureRandom.hex(3)
+      @query = "USE #{db_name}; SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '#{@table_name}';"
+
+      ensure_sqlserver_database(host, db_name)
+    end
+
+    after(:all) do
+      # remove the newly created instance
+      ensure_sqlserver_database(host, 'absent')
+    end
+
+    it "Run a simple tsql command via sqlserver_tsql:" do
+      pp = <<-MANIFEST
+      sqlserver::config{'MSSQLSERVER':
+        instance_name    => 'MSSQLSERVER',
+        admin_login_type => 'WINDOWS_LOGIN',
+      }
+      sqlserver_tsql{'testsqlserver_tsql':
+        instance => 'MSSQLSERVER',
+        database => '#{db_name}',
+        command  => "CREATE TABLE #{@table_name} (id INT, name VARCHAR(20), email VARCHAR(20));",
+      }
+      MANIFEST
+      apply_manifest_on(host, pp) do |r|
+        expect(r.stderr).not_to match(/Error/i)
+      end
+
+      puts "validate the result of tsql command and table #{@table_name} should be created:"
+      run_sql_query_opts = {
+          :query              => @query,
+          :sql_admin_user     => @admin_user,
+          :sql_admin_pass     => @admin_pass,
+          :expected_row_count => 1,
+      }
+      run_sql_query(host, run_sql_query_opts)
+    end
+  end
+
+  context "Test sqlserver_tsql with default SQL Server based authentication", {:testrail => ['89024', '89025', '89026', '89068', '89069']} do
 
     before(:all) do
       # Create new database

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -18,40 +18,67 @@ RSpec.describe 'sqlserver::config', :type => :define do
     }
   end
 
-  context 'without admin_pass' do
-    let(:params) { {
-      :instance_name => 'MSSQLSERVER',
-      :admin_user => 'sa',
-    } }
+  context 'SQL Server based authentication' do
+    context 'without admin_pass' do
+      let(:params) { {
+        :instance_name => 'MSSQLSERVER',
+        :admin_user => 'sa',
+        :admin_login_type => 'SQL_LOGIN',
+      } }
 
-    if Puppet.version < '4.3.0'
-      let(:error_message) { /Must pass admin_pass to Sqlserver::Config/ }
-    else
-      let(:error_message) { /expects a value for parameter 'admin_pass'/ }
+      let(:error_message) { /expects admin_pass to be set for a admin_login_type of SQL_LOGIN/ }
+
+      it {
+        should_not compile
+        expect { catalogue }.to raise_error(Puppet::Error, error_message)
+        }
     end
 
-    it {
-      should_not compile
-      expect { catalogue }.to raise_error(Puppet::Error, error_message)
-      }
+    context 'without admin_user' do
+      let(:params) { {
+        :instance_name => 'MSSQLSERVER',
+        :admin_pass => 'Pupp3t1@',
+        :admin_login_type => 'SQL_LOGIN',
+      } }
+
+      let(:error_message) { /expects admin_user to be set for a admin_login_type of SQL_LOGIN/ }
+
+      it {
+        should_not compile
+        expect { catalogue }.to raise_error(Puppet::Error, error_message)
+        }
+    end
   end
 
-  context 'without admin_user' do
-    let(:params) { {
-      :instance_name => 'MSSQLSERVER',
-      :admin_pass => 'Pupp3t1@',
-    } }
+  context 'SQL Server based authentication' do
+    context 'with admin_user' do
+      let(:params) { {
+        :instance_name => 'MSSQLSERVER',
+        :admin_user => 'sa',
+        :admin_login_type => 'WINDOWS_LOGIN',
+      } }
 
+      let(:error_message) { /expects admin_user to be empty for a admin_login_type of WINDOWS_LOGIN/ }
 
-    if Puppet.version < '4.3.0'
-      let(:error_message) { /Must pass admin_user to Sqlserver::Config/ }
-    else
-      let(:error_message) { /expects a value for parameter 'admin_user'/ }
+      it {
+        should_not compile
+        expect { catalogue }.to raise_error(Puppet::Error, error_message)
+        }
     end
 
-    it {
-      should_not compile
-      expect { catalogue }.to raise_error(Puppet::Error, error_message)
-      }
+    context 'with admin_pass' do
+      let(:params) { {
+        :instance_name => 'MSSQLSERVER',
+        :admin_pass => 'Pupp3t1@',
+        :admin_login_type => 'WINDOWS_LOGIN',
+      } }
+
+      let(:error_message) { /expects admin_pass to be empty for a admin_login_type of WINDOWS_LOGIN/ }
+
+      it {
+        should_not compile
+        expect { catalogue }.to raise_error(Puppet::Error, error_message)
+        }
+    end
   end
 end


### PR DESCRIPTION
Previously to use classes such as sqlserver::login, it would use the
sqlserver::config resource which would contain the credentials to conect to the
database.  However this resource could only authenticate using SQL Server based
authenctiation.  This means that databases that only used Windows based
authentication could not be managed.

This commit modifies the sqlserver::config class with an additional property
called login_type which can be either SQL_LOGIN or WINDOWS_LOGIN, with a default
 of SQL_LOGIN.  The login type also determines the validity of the admin_user and
 admin_pass properties.

The config resource properties are consumed by the get_connection_string method
in sql_connection.  The login_type property then determines whether
'Integrated Security=SSPI' is appended the connection string for connecting to
the database.

Additionally the spec and define tests are modified for the new properties and
default values.
