### PR TITLE
(MODULES-3427) Allow multiple accounts to be used for the SYSADMIN role

### DIFF
--- a/lib/puppet/provider/sqlserver_instance/mssql.rb
+++ b/lib/puppet/provider/sqlserver_instance/mssql.rb
@@ -125,16 +125,32 @@ may be overridden by some command line arguments")
         end
       end
 
-      format_cmd_args_array('/SQLSYSADMINACCOUNTS', @resource[:sql_sysadmin_accounts], cmd_args)
+      format_cmd_args_array('/SQLSYSADMINACCOUNTS', @resource[:sql_sysadmin_accounts], cmd_args, true)
       format_cmd_args_array('/ASSYSADMINACCOUNTS', @resource[:as_sysadmin_accounts], cmd_args)
     end
     cmd_args
   end
 
-  def format_cmd_args_array(switch, arr, cmd_args)
+  def format_cmd_args_array(switch, arr, cmd_args, use_discrete = false)
     if not_nil_and_not_empty? arr
       arr = [arr] if !arr.kind_of?(Array)
-      cmd_args << "#{switch}=#{arr.collect { |item| "\"#{item}\"" }.join(' ')}"
+
+      # The default action is to join the array elements with a space ' ' so the cmd_args ends up like;
+      # ["/SWITCH=\"Element1\" \"Element2\""]
+      # Whereas if use_discrete is set, the args are appended as discrete elements in the cmd_args array e.g.;
+      # ["/SWITCH=\"Element1\"","\"Element2\""]
+
+      if use_discrete
+        arr.map.with_index { |var,i|
+          if i == 0
+            cmd_args << "#{switch}=\"#{var}\""
+          else
+            cmd_args << "\"#{var}\""
+          end
+        }
+      else
+        cmd_args << "#{switch}=#{arr.collect { |item| "\"#{item}\"" }.join(' ')}"
+      end
     end
   end
 

--- a/spec/acceptance/sqlserver_instance_spec.rb
+++ b/spec/acceptance/sqlserver_instance_spec.rb
@@ -11,15 +11,16 @@ end
 describe "sqlserver_instance", :node => host do
   version = host['sql_version'].to_s
 
-
-  def ensure_sqlserver_instance(host, features, inst_name, ensure_val = 'present')
+  def ensure_sqlserver_instance(host, features, inst_name, ensure_val = 'present', sysadmin_accounts = "['Administrator']")
     manifest = <<-MANIFEST
     sqlserver_instance{'#{inst_name}':
       name                  => '#{inst_name}',
       ensure                => <%= ensure_val %>,
       source                => 'H:',
+      security_mode         => 'SQL',
+      sa_pwd                => 'Pupp3t1@',
       features              => [ <%= mssql_features %> ],
-      sql_sysadmin_accounts => ['Administrator'],
+      sql_sysadmin_accounts => #{sysadmin_accounts},
       agt_svc_account       => 'Administrator',
       agt_svc_password      => 'Qu@lity!',
     }
@@ -34,16 +35,67 @@ describe "sqlserver_instance", :node => host do
     end
   end
 
+  #Return options for run_sql_query
+  def run_sql_query_opts (inst_name, query, expected_row_count)
+    run_sql_query_opt = {
+        :query => query,
+        :instance => inst_name,
+        :server => '.',
+        :sql_admin_user => 'sa',
+        :sql_admin_pass => 'Pupp3t1@',
+        :expected_row_count => expected_row_count,
+    }
+  end
+
+  def sql_query_is_user_sysadmin(username)
+    <<-QUERY
+    Select [Name]
+      FROM SYS.Server_Principals
+      WHERE (type = 'S' or type = 'U')
+      AND [Name] like '%\\#{username}'
+      AND is_disabled = 0 AND IS_SRVROLEMEMBER('sysadmin', name) = 1;
+    QUERY
+  end
+
   context "Create an instance", {:testrail => ['88978', '89028', '89031', '89043', '89061']} do
+
+    before(:context) do
+      @ExtraAdminUser = 'ExtraSQLAdmin'
+      pp = <<-MANIFEST
+      user { '#{@ExtraAdminUser}':
+        ensure => present,
+        password => 'Puppet01!',
+      }
+      MANIFEST
+      apply_manifest_on(host,pp)
+    end
+
+    after(:context) do
+      pp = <<-MANIFEST
+      user { '#{@ExtraAdminUser}':
+        ensure => absent,
+      }
+      MANIFEST
+      apply_manifest_on(host,pp)
+    end
+
     inst_name = new_random_instance_name
     features = ['SQL', 'SQLEngine', 'Replication', 'FullText', 'DQ']
 
     it "create #{inst_name} instance" do
-      ensure_sqlserver_instance(host, features, inst_name)
+      ensure_sqlserver_instance(host, features, inst_name,'present',"['Administrator','ExtraSQLAdmin']")
 
       validate_sql_install(host, {:version => version}) do |r|
         expect(r.stdout).to match(/#{Regexp.new(inst_name)}/)
       end
+    end
+
+    it "#{inst_name} instance has Administrator as a sysadmin" do
+      run_sql_query(host, run_sql_query_opts(inst_name, sql_query_is_user_sysadmin('ExtraSQLAdmin'), expected_row_count = 1))
+    end
+
+    it "#{inst_name} instance has ExtraSQLAdmin as a sysadmin" do
+      run_sql_query(host, run_sql_query_opts(inst_name, sql_query_is_user_sysadmin('ExtraSQLAdmin'), expected_row_count = 1))
     end
 
     it "remove #{inst_name} instance" do

--- a/spec/unit/puppet/provider/sqlserver__instance_spec.rb
+++ b/spec/unit/puppet/provider/sqlserver__instance_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'mocha'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sqlserver_install_context.rb'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sqlserver_spec_helper.rb'))
 
 provider_class = Puppet::Type.type(:sqlserver_instance).provider(:mssql)
 
@@ -66,7 +67,13 @@ RSpec.describe provider_class do
       if execute_args[:sql_security_mode]
         cmd_args << "/SECURITYMODE=SQL"
       end
-      cmd_args << "/SQLSYSADMINACCOUNTS=#{ Array.new(@resource[:sql_sysadmin_accounts]).collect { |account| "\"#{account}\"" }.join(' ')}"
+
+      # wrap each arg in doublequotes
+      admin_args = execute_args[:sql_sysadmin_accounts].map { |a| "\"#{a}\"" }
+      # prepend first arg only with CLI switch
+      admin_args[0] = "/SQLSYSADMINACCOUNTS=" + admin_args[0]
+      cmd_args += admin_args
+
       additional_install_switches.each do |switch|
         cmd_args << switch
       end


### PR DESCRIPTION
Previously there was a bug in the way the module constructed the command line
to install SQL server with multiple SA role accounts.  Each additional account
should be a separate command line parameter instead of combining all accounts
into a single parameter.  This commit changes how the command line arguments are
constructed so that each admin account has its own element in the command line
argument array.  This commit also modifies the spec tests to ensure this
behavior is used.
