### PR TITLE
(MODULES-3202) Fix install dependencies with custom source

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ Installs and configures features such as SSMS and Master Data Service.
 
 * `pid`: *Optional.* Supplies a product key to configure which edition of SQL Server to use. Valid options: a string containing a valid product key. Default: undef (if not specified, SQL Server runs in Evaluation mode).
 
+* `source`: *Required.* Locates the SQL Server installer. Valid options: a string containing the path to an executable. Puppet must have permission to execute the installer.
+
+* `windows_feature_source`: *Optional.* Specifies the location of the Windows Feature source files.  This may be needed to install the .Net Framework. See https://support.microsoft.com/en-us/kb/2734782 for more information.
+
 Please note that if an option is set in both its own specific parameter and `install_switches`, the specifically named parameter takes precedence. For example, if you set the product key in both `pid` and in `install_switches`, SQL Server honors the `pid` parameter.
 
 For more information about installer switches and configuring SQL Server, see the links below:
@@ -258,6 +262,8 @@ Installs and configures a SQL Server instance.
 * `sql_svc_password`: *Required if `sql_svc_account` points to a domain account. Invalid for system accounts.* Supplies the password for the SQL Server service's user account. Valid options: a string containing a valid password.
 
 * `sql_sysadmin_accounts`: *Required.* Specifies one or more SQL or system accounts to receive sysadmin status. Valid options: an array containing one or more valid usernames.
+
+* `windows_feature_source`: *Optional.* Specifies the location of the Windows Feature source files.  This may be needed to install the .Net Framework. See https://support.microsoft.com/en-us/kb/2734782 for more information.
 
 Please note that if an option is set in both its own specific parameter and `install_switches`, the specifically named parameter takes precedence. For example, if you set the product key in both `pid` and in `install_switches`, SQL Server honors the `pid` parameter.
 

--- a/lib/puppet/provider/sqlserver_features/mssql.rb
+++ b/lib/puppet/provider/sqlserver_features/mssql.rb
@@ -99,8 +99,8 @@ may be overridden by some command line arguments")
     return nil
   end
 
-  def installNet35
-    result = Puppet::Provider::Sqlserver.run_install_dot_net
+  def installNet35(source_location = nil)
+    result = Puppet::Provider::Sqlserver.run_install_dot_net(source_location)
   end
 
   def create
@@ -108,7 +108,7 @@ may be overridden by some command line arguments")
       warn "Uninstalling all sql server features not tied into an instance because an empty array was passed, please use ensure absent instead."
       destroy
     else
-      installNet35
+      installNet35(@resource[:windows_feature_source])
       debug "Installing features #{@resource[:features]}"
       add_features(@resource[:features])
       @property_hash[:features] = @resource[:features]

--- a/lib/puppet/provider/sqlserver_instance/mssql.rb
+++ b/lib/puppet/provider/sqlserver_instance/mssql.rb
@@ -57,8 +57,8 @@ Puppet::Type::type(:sqlserver_instance).provide(:mssql, :parent => Puppet::Provi
     end
   end
 
-  def installNet35
-    result = Puppet::Provider::Sqlserver.run_install_dot_net
+  def installNet35(source_location = nil)
+    result = Puppet::Provider::Sqlserver.run_install_dot_net(source_location)
   end
 
   def create
@@ -66,7 +66,7 @@ Puppet::Type::type(:sqlserver_instance).provide(:mssql, :parent => Puppet::Provi
       warn "Uninstalling all features for instance #{@resource[:name]} because an empty array was passed, please use ensure absent instead."
       destroy
     else
-      installNet35
+      installNet35(@resource[:windows_feature_source])
       add_features(@resource[:features])
       # cmd_args = build_cmd_args(@resource[:features])
       # begin

--- a/lib/puppet/type/sqlserver_features.rb
+++ b/lib/puppet/type/sqlserver_features.rb
@@ -14,6 +14,11 @@ Puppet::Type::newtype(:sqlserver_features) do
 
   newparam(:source)
 
+  newparam(:windows_feature_source) do
+    desc 'Specify the location of the Windows Feature source files.  This may be needed to install the .Net Framework.
+          See https://support.microsoft.com/en-us/kb/2734782 for more information.'
+  end
+
   newparam(:pid) do
     desc 'Specify the SQL Server product key to configure which edition you would like to use.'
 

--- a/lib/puppet/type/sqlserver_instance.rb
+++ b/lib/puppet/type/sqlserver_instance.rb
@@ -15,6 +15,11 @@ Puppet::Type::newtype(:sqlserver_instance) do
 
   end
 
+  newparam(:windows_feature_source) do
+    desc 'Specify the location of the Windows Feature source files.  This may be needed to install the .Net Framework.
+          See https://support.microsoft.com/en-us/kb/2734782 for more information.'
+  end
+
   newparam(:pid) do
     desc 'Specify the SQL Server product key to configure which edition you would like to use.'
 


### PR DESCRIPTION
Previously the SQL Server module would try to install .Net Framework 3.5 from a
custom source, however the source was never exposed on the feature or instance
provider and type.

This commit:
- Adds a new parameter to the feature and instance type called
  `windows_feature_source` which can be used to set the `/Source` attriute
  during a call to DISM.  See https://support.microsoft.com/en-us/kb/2734782 for
  more information about installing from a custom source
- Modifies the installation logic so that it only calls DISM once if the feature
  exists.  Previously it was called three times.
- Documents the new parameter to the README
- Adds the missing `source` parameter to the feature type in the README
- Only adds the `/Source` parameter to the DISM call, if it is specified in the
  resource
- Modifies the error message to only mentioned the windows_source_location if it
  was specified in the resource
- Removed redundant call to Install-WindowsFeature
