### PR TITLE
(maint) Prime Feature and Instance installation with .Net 3.5 source

### DIFF
--- a/spec/acceptance/sqlserver_config_spec.rb
+++ b/spec/acceptance/sqlserver_config_spec.rb
@@ -21,6 +21,7 @@ describe "sqlserver::config test", :node => host do
       sql_sysadmin_accounts => ['Administrator'],
       security_mode         => 'SQL',
       sa_pwd                => 'Pupp3t1@',
+      windows_feature_source => 'I:\\sources\\sxs',
     }
     MANIFEST
 

--- a/spec/acceptance/sqlserver_instance_spec.rb
+++ b/spec/acceptance/sqlserver_instance_spec.rb
@@ -23,6 +23,7 @@ describe "sqlserver_instance", :node => host do
       sql_sysadmin_accounts => #{sysadmin_accounts},
       agt_svc_account       => 'Administrator',
       agt_svc_password      => 'Qu@lity!',
+      windows_feature_source => 'I:\\sources\\sxs',
     }
     MANIFEST
 

--- a/spec/acceptance/z_last_sqlserver_features_spec.rb
+++ b/spec/acceptance/z_last_sqlserver_features_spec.rb
@@ -18,6 +18,7 @@ describe "sqlserver_features", :node => host do
       is_svc_account    => "$::hostname\\\\Administrator",
       is_svc_password   => 'Qu@lity!',
       features          => [ <%= mssql_features %> ],
+      windows_feature_source => 'I:\\sources\\sxs',
     }
     MANIFEST
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,6 +3,8 @@ require 'beaker-rspec/helpers/serverspec'
 require 'sql_testing_helpers'
 require 'beaker/puppet_install_helper'
 
+WIN_ISO_ROOT = "http://int-resources.ops.puppetlabs.net/ISO/Windows/2012"
+WIN_2012R2_ISO = "en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso"
 QA_RESOURCE_ROOT = "http://int-resources.ops.puppetlabs.net/QA_resources/microsoft_sql/iso/"
 SQL_2014_ISO = "SQLServer2014-x64-ENU.iso"
 SQL_2012_ISO = "SQLServer2012SP1-FullSlipstream-ENU-x64.iso"
@@ -69,6 +71,14 @@ unless ENV['MODULE_provision'] == 'no'
 
     # Install sqlserver dependencies.
     on(agent, puppet('module install puppetlabs-stdlib'))
+
+    # Mount windows 2012R2 ISO to allow install of .NET 3.5 Windows Feature
+    iso_opts = {
+        :folder       => WIN_ISO_ROOT,
+        :file         => WIN_2012R2_ISO,
+        :drive_letter => 'I'
+    }
+    mount_iso(agent, iso_opts)
 
     # Install sqlserver module from local source.
     # See FM-5062 for more details.

--- a/spec/sql_testing_helpers.rb
+++ b/spec/sql_testing_helpers.rb
@@ -1,19 +1,20 @@
+
 def mount_iso(host, opts = {})
-  # This method mounts the ISO on a given host
-  qa_iso_resource_root = opts[:qa_iso_resource_root]
-  sqlserver_iso = opts[:sqlserver_iso]
-  sqlserver_version = opts[:sqlserver_version]
+  folder = opts[:folder];
+  file = opts[:file];
+  drive_letter = opts[:drive_letter];
+
   pp = <<-MANIFEST
-  $p_src  = '#{qa_iso_resource_root}/#{sqlserver_iso}'
-  $source = 'C:\\#{sqlserver_iso}'
-  pget{"Download #{sqlserver_version} Iso":
+  $p_src  = '#{folder}/#{file}'
+  $source = 'C:\\#{file}'
+  pget{"Download #{file} Iso":
     source  => $p_src,
     target  => 'C:',
     timeout => 150000,
   }
   mount_iso{$source:
-    require      => Pget['Download #{sqlserver_version} Iso'],
-    drive_letter => 'H',
+    require      => Pget['Download #{file} Iso'],
+    drive_letter => '#{drive_letter}',
   }
   MANIFEST
   apply_manifest_on(host, pp)
@@ -37,7 +38,8 @@ def install_sqlserver(host, opts = {})
         'INSTANCEDIR'         => 'C:\\Program Files\\Microsoft SQL Server',
         'INSTALLSHAREDDIR'    => 'C:\\Program Files\\Microsoft SQL Server',
         'INSTALLSHAREDWOWDIR' => 'C:\\Program Files (x86)\\Microsoft SQL Server',
-      }
+      },
+      windows_feature_source => 'I:\\sources\\sxs',
     }
     MANIFEST
     apply_manifest_on(host, pp)
@@ -83,15 +85,15 @@ def base_install(sql_version)
   case sql_version.to_i
   when 2012
     iso_opts = {
-      :qa_iso_resource_root   => QA_RESOURCE_ROOT,
-      :sqlserver_iso          => SQL_2012_ISO,
-      :sqlserver_version      => '2012',
+      :folder       => QA_RESOURCE_ROOT,
+      :file         => SQL_2012_ISO,
+      :drive_letter => 'H'
     }
   when 2014
     iso_opts = {
-      :qa_iso_resource_root   => QA_RESOURCE_ROOT,
-      :sqlserver_iso          => SQL_2014_ISO,
-      :sqlserver_version      => '2014',
+      :folder       => QA_RESOURCE_ROOT,
+      :file         => SQL_2014_ISO,
+      :drive_letter => 'H'
     }
   end
   host = find_only_one('sql_host')


### PR DESCRIPTION
Previously, there was known bug with installing .Net Framework 3.5 on Server
2012R2 due to the installation media not making the required features available,
instead they were removed.  This commit copies and mounts a Windows Server
2012 R2 installation ISO and uses the `windows_feature_source`  property in the
module to use the `I:\source\sxs` folder for feature installation components.