### PR TITLE
[PE-17491] Do not fail on install when a restart exit code is returned

### DIFF
--- a/lib/puppet/provider/sqlserver.rb
+++ b/lib/puppet/provider/sqlserver.rb
@@ -17,17 +17,19 @@ class Puppet::Provider::Sqlserver < Puppet::Provider
                  'powershell.exe'
                end
 
-  def try_execute(command, msg = nil, obfuscate_strings = nil)
-    begin
-      execute(command.compact)
-    rescue Puppet::ExecutionFailure => error
+  def try_execute(command, msg = nil, obfuscate_strings = nil, acceptable_exit_codes = [0])
+    res = execute(command.compact, failonfail: false)
+
+    unless acceptable_exit_codes.include?(res.exitstatus)
       msg = "Failure occured when trying to install SQL Server #{@resource[:name]}" if msg.nil?
-      msg += " \n #{error}"
+      msg += " \n Execution of '#{command}' returned #{res.exitstatus}: #{res.strip}"
 
       obfuscate_strings.each {|str| msg.gsub!(str, '**HIDDEN VALUE**') } unless obfuscate_strings.nil?
 
       raise Puppet::Error, msg
     end
+
+    res
   end
 
   private

--- a/lib/puppet/provider/sqlserver_features/mssql.rb
+++ b/lib/puppet/provider/sqlserver_features/mssql.rb
@@ -64,7 +64,10 @@ Puppet::Type::type(:sqlserver_features).provide(:mssql, :parent => Puppet::Provi
       begin
         config_file = create_temp_for_install_switch unless action == 'uninstall'
         cmd_args << "/ConfigurationFile=\"#{config_file.path}\"" unless config_file.nil?
-        try_execute(cmd_args, "Unable to #{action} features (#{features.join(', ')})")
+        res = try_execute(cmd_args, "Unable to #{action} features (#{features.join(', ')})", nil, [0, 1641, 3010])
+
+        warn("#{action} of features (#{features.join(', ')} returned exit code 3010 - reboot required")  if res.exitstatus == 3010
+        warn("#{action} of features (#{features.join(', ')} returned exit code 1641 - reboot initiated") if res.exitstatus == 1641
       ensure
         if config_file
           config_file.close

--- a/spec/unit/puppet/sqlserver_spec_helper.rb
+++ b/spec/unit/puppet/sqlserver_spec_helper.rb
@@ -7,15 +7,15 @@ def stub_powershell_call(subject)
   Puppet::Provider::Sqlserver.stubs(:run_install_dot_net).returns()
 end
 
-def stub_add_features(args, features, additional_switches = [])
-  stub_modify_features('install', args, features, additional_switches)
+def stub_add_features(args, features, additional_switches = [], exit_code = 0)
+  stub_modify_features('install', args, features, additional_switches, exit_code)
 end
 
-def stub_remove_features(args, features)
-  stub_modify_features('uninstall', args, features)
+def stub_remove_features(args, features, exit_code = 0)
+  stub_modify_features('uninstall', args, features, [], exit_code)
 end
 
-def stub_modify_features(action, args, features, additional_switches = [])
+def stub_modify_features(action, args, features, additional_switches = [], exit_code = 0)
   cmds = ["#{args[:source]}/setup.exe",
           "/ACTION=#{action}",
           '/Q',
@@ -31,5 +31,8 @@ def stub_modify_features(action, args, features, additional_switches = [])
   additional_switches.each do |switch|
     cmds << switch
   end
-  Puppet::Util::Execution.stubs(:execute).with(cmds).returns(0)
+
+  result = Puppet::Util::Execution::ProcessOutput.new('', exit_code)
+
+  Puppet::Util::Execution.stubs(:execute).with(cmds, failonfail: false).returns(result)
 end


### PR DESCRIPTION
When exit code 3010 is returned from setup.exe upon install the puppet run failed even though the install succeeded, the 3010 exit code just signifies that some changes are pending and a restart is required. 

This change allows the puppet run to succeed when the install returns 3010 exit code and simply raises a warning.