### PR TITLE
(MODULES-4257) Add SQL Server 2016 support in acceptance tests

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,6 +6,7 @@ require 'beaker/puppet_install_helper'
 WIN_ISO_ROOT = "http://int-resources.ops.puppetlabs.net/ISO/Windows/2012"
 WIN_2012R2_ISO = "en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso"
 QA_RESOURCE_ROOT = "http://int-resources.ops.puppetlabs.net/QA_resources/microsoft_sql/iso/"
+SQL_2016_ISO = "en_sql_server_2016_enterprise_with_service_pack_1_x64_dvd_9542382.iso"
 SQL_2014_ISO = "SQLServer2014-x64-ENU.iso"
 SQL_2012_ISO = "SQLServer2012SP1-FullSlipstream-ENU-x64.iso"
 SQL_ADMIN_USER = 'sa'

--- a/spec/sql_testing_helpers.rb
+++ b/spec/sql_testing_helpers.rb
@@ -54,6 +54,8 @@ def run_sql_query(host, opts = {}, &block)
 
   powershell  = <<-EOS
       $Env:Path +=\";C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\110\\Tools\\Binn;C:\\Program Files\\Microsoft SQL Server\\110\\Tools\\Binn\\"
+      $Env:Path +=\";C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\120\\Tools\\Binn;C:\\Program Files\\Microsoft SQL Server\\120\\Tools\\Binn\\"
+      $Env:Path +=\";C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\130\\Tools\\Binn;C:\\Program Files\\Microsoft SQL Server\\130\\Tools\\Binn\\"
       sqlcmd.exe -S #{server}\\#{instance} -U #{sql_admin_user} -P #{sql_admin_pass} -Q \"#{query}\"
   EOS
   # sqlcmd has problem authenticate to sqlserver if the instance is the default one MSSQLSERVER
@@ -93,6 +95,12 @@ def base_install(sql_version)
     iso_opts = {
       :folder       => QA_RESOURCE_ROOT,
       :file         => SQL_2014_ISO,
+      :drive_letter => 'H'
+    }
+  when 2016
+    iso_opts = {
+      :folder       => QA_RESOURCE_ROOT,
+      :file         => SQL_2016_ISO,
       :drive_letter => 'H'
     }
   end


### PR DESCRIPTION
Previously only SQL Server 2012 and 2014 could be used to run the acceptance
tests.  This commit modifies the helpers to support running the tests with
SQL Server 2016:
- Adding the ISO image for SQL Server 2016
- Adding the paths for SQL Server 2016 and SQL Serve 2014 to locate sqlcmd.exe