### PR TITLE
(maint) Update test helper for SQL Server 2016

### DIFF
--- a/spec/sql_testing_helpers.rb
+++ b/spec/sql_testing_helpers.rb
@@ -146,7 +146,7 @@ def remove_sql_instances(host, opts = {})
 end
 
 def get_install_paths(version)
-  vers = { '2012' => '110', '2014' => '120' }
+  vers = { '2012' => '110', '2014' => '120', '2016' => '130' }
 
   raise 'Valid version must be specified' if ! vers.keys.include?(version)
 


### PR DESCRIPTION
Previously the module was updated to support SQL Server 2016 for acceptance
tests however one reference was missed.  This commit adds the install path
detection for SQL Server 2016, which is then used in acceptance tests, such
as sqlserver_instance.