### PR TITLE
(MODULES-5030) Remove service_ensure parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,6 @@ Specifies a security mode for SQL Server. Valid options: 'SQL'. If not specified
 
 Default: `undef`.
 
-##### `service_ensure`
-
-Specifies whether the SQL Server service should be running. Valid options: 'automatic' (Puppet starts the service if it's not running), 'manual' (Puppet takes no action), and 'disable' (Puppet stops the service if it's running).
-
 ##### `source`
 
 *Required.*

--- a/lib/puppet/type/sqlserver_instance.rb
+++ b/lib/puppet/type/sqlserver_instance.rb
@@ -44,11 +44,6 @@ Puppet::Type::newtype(:sqlserver_instance) do
 
   end
 
-  newparam(:service_ensure) do
-    desc 'Automatic will ensure running if stopped, Manual will set to manual and take no action on current state, :diable will stop and change to service disabled'
-    newvalues(:automatic, :manual, :disable)
-  end
-
   newparam(:sql_svc_account, :parent => Puppet::Property::SqlserverLogin) do
     desc 'Account for SQL Server service: Domain\User or system account.'
     # Default to "NT Service\SQLAGENT$#{instance_name}"


### PR DESCRIPTION
Previously the service_ensure parameter was defined in the type however it was
never implemented in the provider.  As such this param had no effect.  This
commit removes the parameter because:
- This parameter is confusing as it is only applicable at installation time,
  not constantly enforced
- Each service can have a different startup type.  This is already possible
  using the install_switches e.g. /BROWSERSVCSTARTUPTYPE=Disabled
- Ongoing Windows service state should really be managed by a puppet manifest
  not by an installation switch