### PR TITLE
(FM-5389) Add missing shared feature SNAC_SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Default: 'present'.
 
 *Required.*
 
-Specifies one or more features to manage. Valid options: 'BC', 'Conn', 'SSMS', 'ADV_SSMS', 'SDK', 'IS', 'MDS', 'BOL', 'DREPLAY_CTLR', 'DREPLAY_CLT'.
+Specifies one or more features to manage. Valid options: 'BC', 'Conn', 'SSMS', 'ADV_SSMS', 'SDK', 'IS', 'MDS', 'BOL', 'DREPLAY_CTLR', 'DREPLAY_CLT', 'SNAC_SDK'.
 
 The 'Tools' feature is deprecated.  Instead specify 'BC', 'SSMS', 'ADV_SSMS', 'Conn', and 'SDK' explicitly.
 

--- a/lib/puppet/type/sqlserver_features.rb
+++ b/lib/puppet/type/sqlserver_features.rb
@@ -37,7 +37,7 @@ Puppet::Type::newtype(:sqlserver_features) do
   newproperty(:features, :array_matching => :all) do
     desc 'Specifies features to install, uninstall, or upgrade. The list of top-level features include
          BC, Conn, SSMS, ADV_SSMS, SDK, IS and MDS.'
-    newvalues(:Tools, :BC, :Conn, :SSMS, :ADV_SSMS, :SDK, :IS, :MDS, :BOL, :DREPLAY_CTLR, :DREPLAY_CLT)
+    newvalues(:Tools, :BC, :Conn, :SSMS, :ADV_SSMS, :SDK, :IS, :MDS, :BOL, :DREPLAY_CTLR, :DREPLAY_CLT, :SNAC_SDK)
     munge do |value|
       if PuppetX::Sqlserver::ServerHelper.is_super_feature(value)
         Puppet.deprecation_warning("Using #{value} is deprecated for features in sql_features resources")

--- a/lib/puppet_x/sqlserver/features.rb
+++ b/lib/puppet_x/sqlserver/features.rb
@@ -174,6 +174,7 @@ module PuppetX
           'SQL_DReplay_Controller' => 'DREPLAY_CTLR', # Distributed Replay Controller
           'SQL_DReplay_Client'     => 'DREPLAY_CLT', # Distributed Replay Client
           'sql_shared_mr'          => 'SQL_SHARED_MR', # R Server (Standalone)
+          'SQL_SNAC_SDK'           => 'SNAC_SDK', # SQL Client Connectivity SDK
 
           # also WMI: SqlService WHERE SQLServiceType = 4 # MsDtsServer
           'SQL_DTS_Full'           => 'IS', # Integration Services


### PR DESCRIPTION
Previously in commit 84f75b7136 the feature list was extended however it missed
the SQL Native Client SDK.  This commit adds the SNAC_SDK as a detectable and
installable feature.  This commit also updates the README.