### PR TITLE
(MODULES-2386) Using as_sysadmin_accounts without AS feature should error

### DIFF
--- a/lib/puppet/provider/sqlserver_instance/mssql.rb
+++ b/lib/puppet/provider/sqlserver_instance/mssql.rb
@@ -71,6 +71,10 @@ Puppet::Type::type(:sqlserver_instance).provide(:mssql, :parent => Puppet::Provi
       warn "Uninstalling all features for instance #{@resource[:name]} because an empty array was passed, please use ensure absent instead."
       destroy
     else
+      unless @resource[:as_sysadmin_accounts].nil? || @resource[:features].include?('AS')
+        fail('The parameter as_sysadmin_accounts was specified however the AS feature was not included in the installed features.  Either remove the as_sysadmin_accounts parameter or add AS as a feature to the instance.')
+      end
+
       instance_version = PuppetX::Sqlserver::ServerHelper.sql_version_from_install_source(@resource[:source])
       Puppet.debug("Installation source detected as version #{instance_version}") unless instance_version.nil?
 


### PR DESCRIPTION
Previously if the as_sysadmin_accounts parameter was set however the required
AS feature was not in the feature list, then the SQL installation would proceed
and not install AS.  This commit changes the behaviour of the provider to fail
the resource if the as_sysadmin_accounts is set in the sql_instance resource
without the required AS feature in the feature list on creation.