### PR TITLE
(FM-5021) Escaping identifiers when creating a database

### DIFF
--- a/spec/defines/database_spec.rb
+++ b/spec/defines/database_spec.rb
@@ -41,9 +41,15 @@ RSpec.describe 'sqlserver::database', :type => :define do
     end
     it_behaves_like 'sqlserver_tsql command' do
       let(:additional_params) { {
-          :filespec_filename => 'c:/test/test.mdf', :filespec_name => 'myCreCre',
-          :log_filename => "c:/test/logfile.ldf", :log_name => "myCrazyLog"} }
-      let(:should_contain_command) { [/c\:\/test\/logfile\.ldf/] }
+          :filespec_filename => 'c:/test/test.mdf', :filespec_name => 'myCre-Cre',
+          :log_filename => "c:/test/logfile.ldf", :log_name => "myCrazy_Log"} }
+      # Ensure that the parameters are in the TSQL and are correctly escaped
+      let(:should_contain_command) {[
+        /NAME = N'myCre-Cre'/,
+        /FILENAME = N'c\:\/test\/test\.mdf'/,
+        /NAME = N'myCrazy_Log'/,
+        /FILENAME = N'c\:\/test\/logfile\.ldf'/
+      ]}
     end
   end
   describe 'collation_name' do

--- a/templates/create/database.sql.erb
+++ b/templates/create/database.sql.erb
@@ -11,7 +11,7 @@ CREATE DATABASE [<%= @db_name %>]
     CONTAINMENT = <%= @containment %>
     <% if @filespec_name && @filespec_filename -%>
     ON (
-        NAME = <%= @filespec_name %>,
+        NAME = N'<%= @filespec_name %>',
         FILENAME = N'<%= @filespec_filename %>'
         <% if @filespec_size %>, SIZE = <%= @filespec_size %><% end %>
         <% if @filespec_maxsize %>, MAXSIZE = <%= @filespec_maxsize %><% end %>
@@ -21,7 +21,7 @@ CREATE DATABASE [<%= @db_name %>]
     <% if @log_name && @log_filename -%>
         LOG ON
         (
-          NAME = <%= @log_name %>,
+          NAME = N'<%= @log_name %>',
           FILENAME = N'<%= @log_filename %>'
           <% if @log_size %>, SIZE = <%= @log_size %> <% end %>
           <% if @log_maxsize %>, MAXSIZE = <%= @log_maxsize %><% end %>


### PR DESCRIPTION
Previously the name of file and log files were not escaped properly which caused
SQL Server to interpret incorrectly.  The dashes in the name were being seen as
a minus operator.  This commit changes the name of the Log and File files to be
seen as strings instead of identifiers.  This commit also updates the spec tests
to expect these names to be escaped.