### PR TITLE
(MODULES-4915) Remove forced TCP connection for SQL management

### DIFF
--- a/lib/puppet_x/sqlserver/sql_connection.rb
+++ b/lib/puppet_x/sqlserver/sql_connection.rb
@@ -32,7 +32,7 @@ module PuppetX
           'Provider'         => 'SQLOLEDB.1',
           'Initial Catalog'  => config[:database] || 'master',
           'Application Name' => 'Puppet',
-          'Data Source'      => 'localhost'
+          'Data Source'      => '.'
         }
 
         admin_user = config[:admin_user] || ''
@@ -52,7 +52,7 @@ module PuppetX
         end
 
         if config[:instance_name] != nil && config[:instance_name] !~ /^MSSQLSERVER$/
-          params['Data Source'] = "localhost\\#{config[:instance_name]}"
+          params['Data Source'] = ".\\#{config[:instance_name]}"
         end
 
         params.map { |k, v| "#{k}=#{v}" }.join(';')

--- a/spec/unit/puppet_x/sql_connection_spec.rb
+++ b/spec/unit/puppet_x/sql_connection_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PuppetX::Sqlserver::SqlConnection do
     context 'command execution' do
       before :each do
         stub_connection
-        @connection.stubs(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost;User ID=sa;Password=Pupp3t1@')
+        @connection.stubs(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.;User ID=sa;Password=Pupp3t1@')
       end
       it 'should not raise an error but populate has_errors with message' do
         subject.stubs(:execute).raises(Exception.new("SQL Server\n error has happened"))
@@ -43,7 +43,7 @@ RSpec.describe PuppetX::Sqlserver::SqlConnection do
 
       context 'Use default authentication' do
         it 'should defaul to SQL_LOGIN if admin_login_type is not set' do
-          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost;User ID=sa;Password=Pupp3t1@')
+          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.;User ID=sa;Password=Pupp3t1@')
           subject.open_and_run_command('query', {:admin_user => 'sa', :admin_pass => 'Pupp3t1@' })
         end
       end
@@ -66,11 +66,11 @@ RSpec.describe PuppetX::Sqlserver::SqlConnection do
         end
 
         it 'should not add the default instance of MSSQLSERVER to connection string' do
-          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost;User ID=sa;Password=Pupp3t1@')
+          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.;User ID=sa;Password=Pupp3t1@')
           subject.open_and_run_command('query', {:admin_user => 'sa', :admin_pass => 'Pupp3t1@', :instance_name => 'MSSQLSERVER'})
         end
         it 'should add a non default instance to connection string' do
-          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost\\LOGGING;User ID=sa;Password=Pupp3t1@')
+          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.\\LOGGING;User ID=sa;Password=Pupp3t1@')
           subject.open_and_run_command('query', {:admin_user => 'sa', :admin_pass => 'Pupp3t1@', :instance_name => 'LOGGING'})
         end
       end
@@ -93,12 +93,12 @@ RSpec.describe PuppetX::Sqlserver::SqlConnection do
         end
 
         it 'should add integrated security to the connection string if admin and password are empty' do
-          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost;Integrated Security=SSPI')
+          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.;Integrated Security=SSPI')
           subject.open_and_run_command('query', {:admin_user => '', :admin_pass => '', :admin_login_type => 'WINDOWS_LOGIN'})
         end
 
         it 'should add integrated security to the connection string if admin and password are not defined' do
-          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=localhost;Integrated Security=SSPI')
+          @connection.expects(:Open).with('Provider=SQLOLEDB.1;Initial Catalog=master;Application Name=Puppet;Data Source=.;Integrated Security=SSPI')
           subject.open_and_run_command('query', { :admin_login_type => 'WINDOWS_LOGIN' })
         end
       end


### PR DESCRIPTION
Previously the module tried to connect to the SQL instance using the name
localhost.  This had the side effect of always using the TCP based connection.
If a customer used a non-default Port (common practice) then the sql_connection
would not connect.  This commit instead changes the Datasource to use the '.'
moniker which denotes the local machine.  However this instructs the OLE DB
provider to use the enabled protocols enabled for the native client instead of
only using TCP.  This means it will prefer to use the Shared Memory protocol if
enabled.  Also the Shared Memory protocol is required to be enabled for the SQL
Server Agent process on SQL Server 2016.