### PR TITLE
(MODULES-4842) Update puppet compatibility with 4.7 as lower bound

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,10 +9,6 @@ Rakefile:
   unmanaged: true
 spec/spec_helper.rb:
   unmanaged: true
-appveyor.yml:
-  matrix_extras:
-    - PUPPET_GEM_VERSION: 4.2.3
-      RUBY_VER: 21-x64
 LICENSE:
   license_type: 'puppetpe'
 NOTICE:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,6 @@ environment:
     RUBY_VER: 23
   - PUPPET_GEM_VERSION: ~> 4.0
     RUBY_VER: 23-x64
-  - PUPPET_GEM_VERSION: 4.2.3
-    RUBY_VER: 21-x64
-  - PUPPET_GEM_VERSION: 4.2.3
-    RUBY_VER: 21-x64
 matrix:
   fast_finish: true
 install:

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.7.0 < 5.0.0"
+      "version_requirement": ">=4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
The Puppet Agent support is deprecated on many of the versions suggested in the
metadata.  This commit updates the lower bound of the dependency to puppet agent
4.7.0.