### PR TITLE
(maint) Add more advanced examples to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,81 @@ sqlserver_tsql{ 'Always running':
 }
 ```
 
+### Advanced Example
+
+This advanced example will:
+
+* Install the basic SQL Server Engine from installation media mounted at 'D:\' with TCP Enabled and various directories set.
+
+* Uses only Windows based authentication and installs with only the user that Puppet is executing as. Note that the 'sql_sysadmin_accounts' is only applicable during the instance installation and is not actively enforced.
+
+* Creates a sqlserver::config resource which is used in later resources to connect to the newly created instance. As we only support Windows based authentication , a username and password is not required.
+
+* Create a local group called 'DB Administrators', and ensure that it is SQL System Administrator (sysadmin role) along with the account used to install the instance, and that Puppet uses to manage the database instance.
+
+* Ensure that the advanced options for sp_configure are enabled so we can manage the Max Memory setting for the instance.
+
+* Ensure that the Max Memory (MB) configuration item is set to 2048 megabytes.
+
+```puppet
+$sourceloc = 'D:/'
+
+# Install a SQL Server default instance
+sqlserver_instance{'MSSQLSERVER':
+  source                => $sourceloc,
+  features              => ['SQLEngine'],
+  sql_sysadmin_accounts => [$facts['id']],
+  install_switches      => {
+    'TCPENABLED'          => 1,
+    'SQLBACKUPDIR'        => 'C:\\MSSQLSERVER\\backupdir',
+    'SQLTEMPDBDIR'        => 'C:\\MSSQLSERVER\\tempdbdir',
+    'INSTALLSQLDATADIR'   => 'C:\\MSSQLSERVER\\datadir',
+    'INSTANCEDIR'         => 'C:\\Program Files\\Microsoft SQL Server',
+    'INSTALLSHAREDDIR'    => 'C:\\Program Files\\Microsoft SQL Server',
+    'INSTALLSHAREDWOWDIR' => 'C:\\Program Files (x86)\\Microsoft SQL Server'
+  }
+}
+
+# Resource to connect to the DB instance
+sqlserver::config { 'MSSQLSERVER':
+  admin_login_type => 'WINDOWS_LOGIN'
+}
+
+# Enforce SQL Server Administrators
+$local_dba_group_name = 'DB Administrators'
+$local_dba_group_netbios_name = "${facts['hostname']}\\DB Administrators"
+
+group { $local_dba_group_name:
+  ensure => present
+}
+
+-> sqlserver::login { $local_dba_group_netbios_name :
+  login_type  => 'WINDOWS_LOGIN',
+}
+
+-> sqlserver::role { 'sysadmin':
+  ensure   => 'present',
+  instance => 'MSSQLSERVER',
+  type     => 'SERVER',
+  members  => [$local_dba_group_netbios_name, $facts['id']],
+}
+
+# Enforce memory consumption
+sqlserver_tsql {'check advanced sp_configure':
+  command => 'EXEC sp_configure \'show advanced option\', \'1\'; RECONFIGURE;',
+  onlyif => 'sp_configure @configname=\'max server memory (MB)\'',
+  instance => 'MSSQLSERVER'
+}
+
+-> sqlserver::sp_configure { 'MSSQLSERVER-max memory':
+  config_name => 'max server memory (MB)',
+  instance => 'MSSQLSERVER',
+  reconfigure => true,
+  restart => true,
+  value => 2048
+}
+```
+
 ## Reference
 
 ### Types


### PR DESCRIPTION
This commit adds a more advanced manifest to configure an SQL Server.  This
is useful for people to bring together all the different resources etc. in the
module into a single place to see how they can be used.