### PR TITLE
(MODULES-5126) Use integer in acceptance test

### DIFF
--- a/spec/acceptance/sqlserver_user_spec.rb
+++ b/spec/acceptance/sqlserver_user_spec.rb
@@ -25,7 +25,7 @@ describe "sqlserver::user test", :node => host do
     sqlserver::database{ '#{db_name}':
       instance            => 'MSSQLSERVER',
       collation_name      => 'SQL_Estonian_CP1257_CS_AS',
-      compatibility       => '100',
+      compatibility       => 100,
       containment         => 'PARTIAL',
       require             => Sqlserver::Sp_configure['spconfig1']
     }


### PR DESCRIPTION
Previously the user acceptance test setup a database with a string for the
compatibility level, however the resource expects an Integer.  This commit
changes the value to an expected type.