### PR TITLE
(MODULES-5070) Add polybase parameters to sql_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,22 @@ Specifies a product key for SQL Server. Valid options: a string containing a val
 
 Default: `undef`.
 
+##### `polybase_svc_account`
+
+*Only applicable if the POLYBASE feature for SQL Server 2016 is being installed*
+
+Specifies a domain or system account for the Polybase Engine service.
+
+Valid options: a string specifying an existing username.
+
+##### `polybase_svc_password`
+
+*Only applicable if the POLYBASE feature for SQL Server 2016 is being installed*
+
+Specifies the password for the Polybase Engine service
+
+Valid options: a string specifying a valid password.
+
 ##### `rs_svc_account`
 
 Specifies a domain or system account to be used by the report service. Valid options: a string; cannot include any of the following characters: `'"/ \ [ ] : ; | = , + * ? < >'`.  If you specify a domain user account, the domain must be less than 254 characters and the username must be less than 20 characters.

--- a/lib/puppet/type/sqlserver_instance.rb
+++ b/lib/puppet/type/sqlserver_instance.rb
@@ -109,6 +109,16 @@ Puppet::Type::newtype(:sqlserver_instance) do
     end
   end
 
+  newparam(:polybase_svc_account, :parent => Puppet::Property::SqlserverLogin) do
+    desc 'The account used by the Polybase Engine service. Only applicable for SQL Server 2016.'
+
+  end
+
+  newparam(:polybase_svc_password) do
+    desc 'The password for the Polybase Engine service account. Only applicable for SQL Server 2016.'
+
+  end
+
   newparam(:security_mode) do
     desc 'Specifies the security mode for SQL Server.
           If this parameter is not supplied, then Windows-only authentication mode is supported.

--- a/spec/unit/puppet/provider/sqlserver_instance_spec.rb
+++ b/spec/unit/puppet/provider/sqlserver_instance_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe provider_class do
   subject { provider_class }
   let(:additional_install_switches) { [] }
 
+  let(:resourcekey_to_cmdarg) {{
+    'agt_svc_account'       => 'AGTSVCACCOUNT',
+    'agt_svc_password'      => 'AGTSVCPASSWORD',
+    'as_svc_account'        => 'ASSVCACCOUNT',
+    'as_svc_password'       => 'ASSVCPASSWORD',
+    'pid'                   => 'PID',
+    'rs_svc_account'        => 'RSSVCACCOUNT',
+    'rs_svc_password'       => 'RSSVCPASSWORD',
+    'polybase_svc_account'  => 'PBENGSVCACCOUNT',
+    'polybase_svc_password' => 'PBDMSSVCPASSWORD',
+    'sa_pwd'                => 'SAPWD',
+    'security_mode'         => 'SECURITYMODE',
+    'sql_svc_account'       => 'SQLSVCACCOUNT',
+    'sql_svc_password'      => 'SQLSVCPASSWORD',
+  }}
+
   def stub_uninstall(args, installed_features, exit_code = 0)
     cmd_args = ["#{args[:source]}/setup.exe",
                 "/ACTION=uninstall",
@@ -22,32 +38,6 @@ RSpec.describe provider_class do
     Puppet::Util::Execution.stubs(:execute).with(cmd_args.compact, failonfail: false).returns(result)
   end
 
-  shared_examples 'run' do |args, munged_values = {}|
-    it {
-      execute_args = args.merge(munged_values)
-      @resource = Puppet::Type::Sqlserver_instance.new(args)
-      @provider = provider_class.new(@resource)
-
-      stub_powershell_call(subject)
-      stub_source_which_call args[:source]
-
-      cmd_args = ["#{execute_args[:source]}/setup.exe",
-                  "/ACTION=install",
-                  '/Q',
-                  '/IACCEPTSQLSERVERLICENSETERMS',
-                  "/INSTANCENAME=#{execute_args[:name]}",
-                  "/FEATURES=#{execute_args[:features].join(',')}",]
-      (execute_args.keys - %w(ensure loglevel features name source sql_sysadmin_accounts sql_security_mode install_switches).map(&:to_sym)).sort.collect do |key|
-        cmd_args << "/#{key.to_s.gsub(/_/, '').upcase}=\"#{@resource[key]}\""
-      end
-      if execute_args[:sql_security_mode]
-        cmd_args << "/SECURITYMODE=SQL"
-      end
-      cmd_args << "/SQLSYSADMINACCOUNTS=#{ Array.new(@resource[:sql_sysadmin_accounts]).collect { |account| "\"#{account}\"" }.join(' ')}"
-      Puppet::Util::Execution.stubs(:execute).with(cmd_args.compact).returns(0)
-      @provider.create
-    }
-  end
   shared_examples 'create' do |exit_code, warning_matcher|
     it {
       execute_args = args.merge(munged_values)
@@ -64,7 +54,7 @@ RSpec.describe provider_class do
                   "/INSTANCENAME=#{execute_args[:name]}",
                   "/FEATURES=#{execute_args[:features].join(',')}",]
       (execute_args.keys - %w( ensure loglevel features name source sql_sysadmin_accounts sql_security_mode install_switches).map(&:to_sym)).sort.collect do |key|
-        cmd_args << "/#{key.to_s.gsub(/_/, '').upcase}=\"#{@resource[key]}\""
+        cmd_args << "/#{resourcekey_to_cmdarg[key.to_s]}=\"#{@resource[key]}\""
       end
       if execute_args[:sql_security_mode]
         cmd_args << "/SECURITYMODE=SQL"
@@ -106,7 +96,7 @@ RSpec.describe provider_class do
                   "/INSTANCENAME=#{execute_args[:name]}",
                   "/FEATURES=#{execute_args[:features].join(',')}",]
       (execute_args.keys - %w( ensure loglevel features name source sql_sysadmin_accounts sql_security_mode install_switches).map(&:to_sym)).sort.collect do |key|
-        cmd_args << "/#{key.to_s.gsub(/_/, '').upcase}=\"#{@resource[key]}\""
+        cmd_args << "/#{resourcekey_to_cmdarg[key.to_s]}=\"#{@resource[key]}\""
       end
       if execute_args[:sql_security_mode]
         cmd_args << "/SECURITYMODE=SQL"
@@ -154,6 +144,7 @@ RSpec.describe provider_class do
       provider.create
     }
   end
+
   describe 'it should provide the correct command default command' do
     it_behaves_like 'create' do
       args = get_basic_args
@@ -177,6 +168,33 @@ RSpec.describe provider_class do
       let(:munged_values) { munged }
     end
   end
+
+  describe 'it should raise error if polybase_svc_account is specified without POLYBASE feature' do
+    it_behaves_like 'create_failure', 1, /polybase_svc_account was specified however the POLYBASE feature was not included/i do
+      args = get_basic_args
+      args[:features] = ['SQLEngine']
+      args[:polybase_svc_account] = 'username'
+      args.delete(:polybase_svc_password)
+
+      let(:args) { args }
+      munged = {:features => Array.new(args[:features])}
+      let(:munged_values) { munged }
+    end
+  end
+
+  describe 'it should raise error if polybase_svc_password is specified without POLYBASE feature' do
+    it_behaves_like 'create_failure', 1, /polybase_svc_password was specified however the POLYBASE feature was not included/i do
+      args = get_basic_args
+      args[:features] = ['SQLEngine']
+      args.delete(:polybase_svc_account)
+      args[:polybase_svc_password] = 'password'
+
+      let(:args) { args }
+      munged = {:features => Array.new(args[:features])}
+      let(:munged_values) { munged }
+    end
+  end
+
 
   describe 'it should raise warning on install when 1641 exit code returned' do
     it_behaves_like 'create', 1641, /reboot initiated/i do

--- a/spec/unit/puppet/sqlserver_install_context.rb
+++ b/spec/unit/puppet/sqlserver_install_context.rb
@@ -1,26 +1,8 @@
-RSpec.shared_context 'install_arguments' do
-  @install_args = {
-      :source => 'C:\myinstallexecs',
-      :pid => 'areallyCrazyLongPid',
-      :features => %w(SQL AS RS),
-      :name => 'MYSQLSERVER_HOST',
-      :agt_svc_account => 'nexus\travis',
-      :agt_svc_password => 'P@ssword1',
-      :as_svc_account => 'analysisAccount',
-      :as_svc_password => 'CrazySimpleP@ssword',
-      :rs_svc_account => 'reportUserAccount', #always local user
-      :rs_svc_password => 'reportP@ssword1',
-      :sql_svc_account => 'NT Service\MSSQLSERVER',
-      :sql_sysadmin_accounts => ['localAdminAccount', 'nexus\domainUser']
-  }
-  let(:args) { @install_args }
-end
-
 def get_basic_args
   return {
       :source => 'C:\myinstallexecs',
       :pid => 'areallyCrazyLongPid',
-      :features => %w(SQL AS RS),
+      :features => %w(SQL AS RS POLYBASE),
       :name => 'MYSQLSERVER_HOST',
       :agt_svc_account => 'nexus\travis',
       :agt_svc_password => 'P@ssword1',
@@ -28,6 +10,8 @@ def get_basic_args
       :as_svc_password => 'CrazySimpleP@ssword',
       :rs_svc_account => 'reportUserAccount', #always local user
       :rs_svc_password => 'reportP@ssword1',
+      :polybase_svc_account => 'nexus\polyuser',
+      :polybase_svc_password => 'P@ssword1',
       :sql_svc_account => 'NT Service\MSSQLSERVER',
       :sql_sysadmin_accounts => ['localAdminAccount', 'nexus\domainUser']
   }

--- a/spec/unit/puppet/type/sqlserver_instance_spec.rb
+++ b/spec/unit/puppet/type/sqlserver_instance_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Puppet::Type.type(:sqlserver_instance) do
   end
 
   # Failed validation examples
-  shared_examples 'fail validation' do #|args, messages = ['must be set'], error_class = Puppet::Error|
+  shared_examples 'fail validation' do
     it 'should fail with' do
       expect {
         Puppet::Type.type(:sqlserver_instance).new(args)
@@ -54,27 +54,30 @@ RSpec.describe Puppet::Type.type(:sqlserver_instance) do
     end
   end
 
-
-  describe 'should fail when rs_svc_account contains an invalid character' do
+  describe "rs_svc_account" do
     %w(/ \ [ ] : ; | = , + * ? < > ).each do |v|
-      it_should_behave_like 'fail validation' do
-        args = get_basic_args
-        args[:rs_svc_account] = "crazy#{v}User"
-        let(:args) { args }
-        let(:messages) { ['rs_svc_account can not contain any of the special characters,'] }
+      context "contains invalid character #{v}" do
+        it_should_behave_like 'fail validation' do
+          args = get_basic_args
+          args[:rs_svc_account] = "crazy#{v}User"
+          let(:args) { args }
+          let(:messages) { ['rs_svc_account can not contain any of the special characters,'] }
+        end
       end
     end
   end
 
-  context 'must be at least 8 characters long' do
-    it_behaves_like 'fail validation' do
-      args = get_basic_args
-      args[:rs_svc_password] = 'hrt'
-      let(:args) { args }
-      let(:messages) { ['must be at least 8 characters long', 'must contain uppercase letters',
-                        'must contain numbers',
-                        'must contain a special character'] }
-
+  describe "rs_svc_password" do
+    context 'when less than 8 characters long' do
+      it_behaves_like 'fail validation' do
+        args = get_basic_args
+        args[:rs_svc_password] = 'hrt'
+        let(:args) { args }
+        let(:messages) { ['must be at least 8 characters long',
+                          'must contain uppercase letters',
+                          'must contain numbers',
+                          'must contain a special character'] }
+      end
     end
   end
 end


### PR DESCRIPTION
Previously the PolyBase features were added to sql_instance however the config
settings for username and password were not surfaced on the type.  This commit:
- Adds the polybase_svc_account and polybase_svc_password parameters to the
  sql_instance
- Adds checks to the provider so an error is thrown if the polybase params are
  set, but no polybase feature is being installed
- Previously the code assumed the puppet parameter names directly lined up with
  SQL Server installation command line switches however for Polybase, this is
  not true.  This commit changes to using a simple lookup hashtable
- This commit also removes a shared example called 'run' and install helper as
  they were not being used in any tests.