### PR TITLE
(maint) modulesync 892c4cf

### DIFF
--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -22,4 +22,5 @@ gettext:
   # Patterns for +Dir.glob+ used to find all files that might contain
   # translatable content, relative to the project root directory
   source_files:
+      - './lib/**/*.rb'
   


### PR DESCRIPTION
Once this is merged, it’d be much appreciated if the merger could remove the `msync_18sep17_892c4cf` branch from the `puppetlabs` fork. 

Thank you! 💖