### PR TITLE
(maint) Remove instance during acceptance tests

### DIFF
--- a/spec/acceptance/sqlserver_config_spec.rb
+++ b/spec/acceptance/sqlserver_config_spec.rb
@@ -46,7 +46,7 @@ describe "sqlserver::config test", :node => host do
 
     after(:all) do
       # remove the newly created instance
-      ensure_sqlserver_instance('absent')
+      ensure_sqlserver_instance(inst_name, 'absent')
     end
 
     it 'Create New Admin Login:', :tier_low => true do


### PR DESCRIPTION
Previously during the sqlserver_config acceptance tests multiple database
instances were being created, instead of destroyed, for example a datbase
instance of 'abseny' was being created.  This commit fixes this test fixture
failure by calling the ensure_sqlserver_instance helper method with the correct
parameters to remove an instance.