### PR TITLE
(MAINT) Correct supported versions & platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ Microsoft SQL Server is a database platform for Windows. The sqlserver module le
 
 The sqlserver module requires the following:
 
-* Puppet Enterprise 3.7 or later.
 * .NET 3.5. (Installed automatically if not present. This might require an internet connection.)
 * The contents of the SQL Server ISO file, mounted or extracted either locally or on a network share.
-* Windows Server 2012 or 2012 R2.
+* Windows Server 2012, 2012 R2, or 2016.
 
 ### Beginning with sqlserver
 


### PR DESCRIPTION
This commit corrects the minimum supported version of Puppet Enterprise
from `3.7` to `4.7.0` in the Setup Requirements section of the readme.
It also adds Windows Server 2016 as a supported option in the same
section of the readme.