### PR TITLE
(FM-6464) Update metadata for open sourcing

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "Puppet Inc",
   "summary": "The `sqlserver` module installs and manages MS SQL Server 2012, 2014 and 2016 on Windows systems.",
   "license": "proprietary",
-  "source": "https://tickets.puppet.com/browse/MODULES/component/12400",
+  "source": "https://github.com/puppetlabs/puppetlabs-sqlserver",
   "project_page": "https://github.com/puppetlabs/puppetlabs-sqlserver",
   "issues_url": "https://tickets.puppet.com/browse/MODULES/component/12400",
   "tags": [


### PR DESCRIPTION
This commit updates the metadata for the module, pointing the source
at the github repository instead of JIRA ticketing. Once the module's
source code is publicly available, users should be able to link to it
instead of being redirected to the ticketing system.