### PR TITLE
(WIP) (MODULES-6022) Fix Instance Unnecessary Reinstall

### DIFF
--- a/lib/puppet_x/sqlserver/features.rb
+++ b/lib/puppet_x/sqlserver/features.rb
@@ -247,9 +247,9 @@ module PuppetX
         # it's possible to request information for a valid instance_name but not for version.  In this case
         # we just return nil.
         return nil if sql_instance['reg_root'].nil?
-
-        feats = sql_instance['reg_root'].map do |reg_root|
-          get_instance_features(reg_root, sql_instance['name'])
+        feats = []
+        sql_instance['reg_root'].each do |reg_root|
+          feats += get_instance_features(reg_root, sql_instance['name'])
         end
         sql_instance.merge({'features' => feats.uniq})
       end

--- a/spec/acceptance/sqlserver_instance_spec.rb
+++ b/spec/acceptance/sqlserver_instance_spec.rb
@@ -31,9 +31,8 @@ describe "sqlserver_instance", :node => host do
 
     pp = ERB.new(manifest).result(binding)
 
-    execute_manifest(pp) do |r|
-      expect(r.stderr).not_to match(/Error/i)
-    end
+    execute_manifest(pp,{:catch_failures => true})
+    execute_manifest(pp,{:catch_changes => true})
   end
 
   #Return options for run_sql_query


### PR DESCRIPTION
Prior to this commit, applying a manifest that ensures a SQL
instance is installed with any features will always attempt to
uninstall and reinstall those features on subsequent applies.
This was due to a bug in the code returning discovered features
nested inside of a needless array. This commit flattens out the
unneeded array and causes the discovery code to correctly find
any installed features.