### PR TITLE
(MODULES-6022) Make SQLServer Instance Idempotent Again

### DIFF
--- a/lib/puppet_x/sqlserver/features.rb
+++ b/lib/puppet_x/sqlserver/features.rb
@@ -247,9 +247,9 @@ module PuppetX
         # it's possible to request information for a valid instance_name but not for version.  In this case
         # we just return nil.
         return nil if sql_instance['reg_root'].nil?
-
-        feats = sql_instance['reg_root'].map do |reg_root|
-          get_instance_features(reg_root, sql_instance['name'])
+        feats = []
+        sql_instance['reg_root'].each do |reg_root|
+          feats += get_instance_features(reg_root, sql_instance['name'])
         end
         sql_instance.merge({'features' => feats.uniq})
       end

--- a/spec/acceptance/sqlserver_instance_spec.rb
+++ b/spec/acceptance/sqlserver_instance_spec.rb
@@ -31,9 +31,8 @@ describe "sqlserver_instance", :node => host do
 
     pp = ERB.new(manifest).result(binding)
 
-    execute_manifest(pp) do |r|
-      expect(r.stderr).not_to match(/Error/i)
-    end
+    execute_manifest(pp,{:catch_failures => true})
+    execute_manifest(pp,{:catch_changes => true})
   end
 
   #Return options for run_sql_query
@@ -83,7 +82,7 @@ describe "sqlserver_instance", :node => host do
     inst_name = new_random_instance_name
     features = ['SQLEngine', 'Replication', 'FullText', 'DQ']
 
-    it "create #{inst_name} instance", :tier_low => true do
+    it "create #{inst_name} instance", :tier_high => true do
       ensure_sqlserver_instance(features, inst_name,'present',"['Administrator','ExtraSQLAdmin']")
 
       validate_sql_install(host, {:version => version}) do |r|
@@ -99,7 +98,7 @@ describe "sqlserver_instance", :node => host do
       run_sql_query(host, run_sql_query_opts(inst_name, sql_query_is_user_sysadmin('ExtraSQLAdmin'), expected_row_count = 1))
     end
 
-    it "remove #{inst_name} instance", :tier_low => true do
+    it "remove #{inst_name} instance", :tier_high => true do
       ensure_sqlserver_instance(features, inst_name, 'absent')
 
       # Ensure all features for this instance are removed and the defaults are left alone
@@ -122,7 +121,7 @@ describe "sqlserver_instance", :node => host do
       ensure_sqlserver_instance(features, inst_name, 'absent')
     end
 
-    it "create #{inst_name} instance with only one RS feature", :tier_low => true do
+    it "create #{inst_name} instance with only one RS feature", :tier_high => true do
       ensure_sqlserver_instance(features, inst_name)
 
       validate_sql_install(host, {:version => version}) do |r|


### PR DESCRIPTION
Fix issues with idempotency as a result of the changes in 2.0.1 to retrieve facts information from registry instead of WMI. Also updates acceptance tests to validate idempotency. Increases the test tier for changed tests to `high` per @ThoughtCrhyme's suggestion.

Supersedes #249 which was accidentally based on a branch on upstream instead of my fork. 🤦‍♂️ 