### PR TITLE
(MODULES-6356) Fixes a problem still remaining from MODULES-2904

### DIFF
--- a/lib/puppet/provider/sqlserver_instance/mssql.rb
+++ b/lib/puppet/provider/sqlserver_instance/mssql.rb
@@ -171,9 +171,9 @@ Puppet::Type::type(:sqlserver_instance).provide(:mssql, :parent => Puppet::Provi
       if use_discrete
         arr.map.with_index { |var,i|
           if i == 0
-            cmd_args << "#{switch}=\"#{var}\""
+            cmd_args << "#{switch}=#{var}"
           else
-            cmd_args << "\"#{var}\""
+            cmd_args << "#{var}"
           end
         }
       else

--- a/spec/acceptance/sqlserver_instance_spec.rb
+++ b/spec/acceptance/sqlserver_instance_spec.rb
@@ -60,7 +60,8 @@ describe "sqlserver_instance", :node => host do
   context "Create an instance", {:testrail => ['88978', '89028', '89031', '89043', '89061']} do
 
     before(:context) do
-      @ExtraAdminUser = 'ExtraSQLAdmin'
+      # Use a username with a space to test argument parsing works correctly
+      @ExtraAdminUser = 'Extra SQLAdmin'
       pp = <<-MANIFEST
       user { '#{@ExtraAdminUser}':
         ensure => present,
@@ -83,7 +84,8 @@ describe "sqlserver_instance", :node => host do
     features = ['SQLEngine', 'Replication', 'FullText', 'DQ']
 
     it "create #{inst_name} instance", :tier_high => true do
-      ensure_sqlserver_instance(features, inst_name,'present',"['Administrator','ExtraSQLAdmin']")
+      host_computer_name = on(host, 'CMD /C ECHO %COMPUTERNAME%').stdout.chomp
+      ensure_sqlserver_instance(features, inst_name,'present',"['Administrator','#{host_computer_name}\\#{@ExtraAdminUser}']")
 
       validate_sql_install(host, {:version => version}) do |r|
         expect(r.stdout).to match(/#{Regexp.new(inst_name)}/)
@@ -95,7 +97,7 @@ describe "sqlserver_instance", :node => host do
     end
 
     it "#{inst_name} instance has ExtraSQLAdmin as a sysadmin", :tier_low => true do
-      run_sql_query(host, run_sql_query_opts(inst_name, sql_query_is_user_sysadmin('ExtraSQLAdmin'), expected_row_count = 1))
+      run_sql_query(host, run_sql_query_opts(inst_name, sql_query_is_user_sysadmin(@ExtraAdminUser), expected_row_count = 1))
     end
 
     it "remove #{inst_name} instance", :tier_high => true do

--- a/spec/unit/puppet/provider/sqlserver_instance_spec.rb
+++ b/spec/unit/puppet/provider/sqlserver_instance_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe provider_class do
         cmd_args << "/SECURITYMODE=SQL"
       end
 
-      # wrap each arg in doublequotes
-      admin_args = execute_args[:sql_sysadmin_accounts].map { |a| "\"#{a}\"" }
+      # Extrace the SQL Sysadmins
+      admin_args = execute_args[:sql_sysadmin_accounts].map { |a| "#{a}" }
       # prepend first arg only with CLI switch
       admin_args[0] = "/SQLSYSADMINACCOUNTS=" + admin_args[0]
       cmd_args += admin_args


### PR DESCRIPTION
As described in MODULES-2904, installation fails with an array of SQL Admins. This was fixed in the use_discrete=true block (line 171-178. However the double quotes also needed to be removed from the list of accounts for the /SQLSYSADMINACCOUNTS switch parameter. 
This PR removes the double quotes in the use_discrete=true section (which is only used for /SQLSYSADMINACCOUNTS). I have tested this to sucessfully fix installation for the following scenario's:
- SQL 2016 on Win2016 with 1 local group specified for SQLSYSADMINACCOUNTS
- SQL 2016 on Win2016 with 1 domain group specified for SQLSYSADMINACCOUNTS
- SQL 2016 on Win2016 with 3 groups (1 local, 1 domain and BUILTIN\Administrators) specified for SQLSYSADMINACCOUNTS

Without the fix, the only setting that works is /SQLSYSADMINACCOUNTS="BUILTIN\Administrators", all other settings (both local and domain accounts/groups) will fail.