### PR TITLE
(MAINT) Add unreleased section to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Summary
+
+#### Fixed
+- Ensure that multiple accounts can be included in SQLSYSADMINACCOUNTS when installing SQL Server ([MODULES-6356](https://tickets.puppetlabs.com/browse/MODULES-6356))
+
 ## 2017-12-8 - Supported Release 2.1.0
 
 ### Summary


### PR DESCRIPTION
Prior to this commit the windows team was not tracking
changes prior to release in the changelog. Per the
KeepAChangelog standard, using an unreleased section
provides value to the users and developers both.
Using this section will make release prep easier and
allow users who want to leverage the module from master
to do so with clear knowledge of what changes have
been made to the code since the last release.

This commit adds the unreleased section to the CHANGELOG
and adds notes for the changes.