### PR TITLE
(MODULES-6281) Return Errors from T-SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - During acceptance testing, only execute master provisioning steps if there is
   a master in the hosts array.
 - Stop running ```gem update bundler``` during Travis runs. ([MODULES-6339](https://tickets.puppetlabs.com/browse/MODULES6339))
+- The `sqlserver_tsql` resource now returns errors from sql queries properly. ([MODULES-6281](https://tickets.puppetlabs.com/browse/MODULES-6281))
 
 ## [2.1.0] - 2017-12-8
 

--- a/spec/acceptance/sqlserver_tsql_spec.rb
+++ b/spec/acceptance/sqlserver_tsql_spec.rb
@@ -191,7 +191,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       MANIFEST
       execute_manifest(pp, {:acceptable_exit_codes => [0,1]}) do |r|
-        expect(r.stderr).to match(/Error/i)
+        expect(r.stderr).to match(/Incorrect syntax/i)
       end
     end
 
@@ -210,7 +210,7 @@ describe "sqlserver_tsql test", :node => host do
       }
       MANIFEST
       execute_manifest(pp, {:acceptable_exit_codes => [0,1]}) do |r|
-        expect(r.stderr).to match(/Error/i)
+        expect(r.stderr).to match(/Non-Existing-Database/i)
       end
     end
   end


### PR DESCRIPTION
The sqlserver_tsql resource does not handle errors returned from T-SQL
statements properly. The errors come back from the query but unless the
phrase 'SQL Server' was included in the error text, the error was not
then passed back to the user/logs. This change ensure that errors
returned are passed back properly by inspecting the Errors property of
the ADO object used to run the query. Note that this may not behave as
expected if the error that occurrs is of sufficently low severity that a
rowset, even if empty, is also returned. If a rowset is returned by the
ADO object, the object will not populate the Errors property, and there
is no way to tell a low severity error occurred. For instance 'Select
1/0' returns a low severity division by zero error, and an empty rowset.
Because the empty rowset exists, the error cannot be seen. It is up to
the user to ensure that the errors they want to catch are of sufficient
severity that execution of the query is halted.