### PR TITLE
(MAINT) Fix Changelog Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Fix AppVeyor OpenSSL bug.([Modsync commit with discussion](https://github.com/puppetlabs/modulesync_configs/commit/f04d0d1119cb5cbd4c3aac76047c4c766ae1fcb2))
 - During acceptance testing, only execute master provisioning steps if there is
   a master in the hosts array.
-- Stop running ```gem update bundler``` during Travis runs. ([MODULES-6339](https://tickets.puppetlabs.com/browse/MODULES6339))
+- Stop running `gem update bundler` during Travis runs. ([MODULES-6339](https://tickets.puppetlabs.com/browse/MODULES-6339))
 - The `sqlserver_tsql` resource now returns errors from sql queries properly. ([MODULES-6281](https://tickets.puppetlabs.com/browse/MODULES-6281))
 
 ## [2.1.0] - 2017-12-8


### PR DESCRIPTION
This commit fixes the markdown link to MODULES-6339 explaining why the
command to update bundle was removed from TRAVISCI builds.