### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'sql_testing_helpers'
@@ -26,6 +28,7 @@ end
 
 # Install PE
 run_puppet_install_helper
+configure_type_defaults_on(hosts)
 
 # Install PE License onto Master, if one exists.
 install_pe_license(master) unless hosts_as("master").empty?


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.6.0` 
