### PR TITLE
(maint) Spec fixes

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,8 @@ RSpec.configure do |c|
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level
-    Puppet.settings[:strict] = :warning
+    # newer versions of Puppet remove :strict
+    Puppet.settings[:strict] = :warning if Puppet.settings.include?(:strict)
   end
 end
 

--- a/spec/unit/puppet_x/sql_connection_spec.rb
+++ b/spec/unit/puppet_x/sql_connection_spec.rb
@@ -24,12 +24,13 @@ RSpec.describe PuppetX::Sqlserver::SqlConnection do
         @connection.stubs(:Open).with('Provider=SQLNCLI11;Initial Catalog=master;Application Name=Puppet;Data Source=.;DataTypeComptibility=80;User ID=sa;Password=Pupp3t1@')
       end
       it 'should not raise an error but populate has_errors with message' do
-        @connection.Errors.stubs(:count).returns(1)
-        @connection.Errors.stubs(:Description).returns("SQL Error in Connection")
+        @connection.Errors.stubs(:count).returns(2)
+        @connection.expects(:Errors).with(0).returns(stub( { :Description => "SQL Error in Connection" }))
+        @connection.expects(:Errors).with(1).returns(stub( { :Description => "Rowdy Roddy Piper" }))
         expect {
           result = subject.open_and_run_command('whacka whacka whacka', config)
           expect(result.exitstatus).to eq(1)
-          expect(result.error_message).to eq('SQL Error in Connection')
+          expect(result.error_message).to eq("SQL Error in Connection\nRowdy Roddy Piper")
         }.to_not raise_error(Exception)
 
       end


### PR DESCRIPTION
- Prior code from 9b8a0fe used a non-obvious
   behavior in the mocking framework to return the Description value from an
   error instance.

   If the count of errors was returned was increased by 1, the code would be
   subtly wrong as mocks are generating to each call of .Errors(x) with the
   supplied values.

 - Instead, more clearly mock the actual code path, and additionally provide
   two separate messages, demonstrating they are iterated and joined properly