### PR TITLE
add to tsql command due to duplicate resource name

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -107,7 +107,7 @@ define sqlserver::role(
     }
 
     if size($members) > 0 or $members_purge == true {
-      sqlserver_tsql{ "role-${role}-members":
+      sqlserver_tsql{ "role-${role}-${database}-members":
         command  => template('sqlserver/create/role/members.sql.erb'),
         onlyif   => template('sqlserver/query/role/member_exists.sql.erb'),
         instance => $instance,


### PR DESCRIPTION
adding -${database} so we could remove duplicated resources error when we need to assign a user to the same role name in different databases. 
this was done to resolve an issue where we needed to set the db_datareader in two different databases but because the tsql command name was only referencing the role and not the database it was getting a puppet compile error on duplicated resources. $database does have a default of master so this should be the smallest change needed to fix this issue. I have tested this and it appears to work fine .. but this is my first PR .. so be nice ;) 