### PR TITLE
(MODULES-7801) Fix Gem Dependencies

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,11 +5,13 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         platforms: ruby
+        version: '>= 0.3.10'
       - gem: 'puppet-module-win-system-r#{minor_version}'
         platforms:
           - mswin
           - mingw
           - x64_mingw
+        version: '>= 0.3.10'
       - gem: beaker-testmode_switcher
         version: '~> 0.4'
       - gem: master_manipulator

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,11 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",  require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}",    require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker-testmode_switcher", '~> 0.4',            require: false
-  gem "master_manipulator",                            require: false
-  gem "puppet-blacksmith", '~> 3.4',                   require: false
+  gem "puppet-module-posix-system-r#{minor_version}", '>= 0.3.10', require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '>= 0.3.10',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "beaker-testmode_switcher", '~> 0.4',                        require: false
+  gem "master_manipulator",                                        require: false
+  gem "puppet-blacksmith", '~> 3.4',                               require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
PDKified modules depend on puppet-module-posix-system-r2.3 and
puppet-module-win-system-r2.3 to bring in gems such as beaker-pe
which previously were explicitly specified in the Gemfile. Bringing in
those dependencies requires version 0.3.10 or greater, which is not
specified in the Gemfile. This has caused cases where a lower version
is brought into the bundle and testing breaks in CI and on the local
machines.