### PR TITLE
(MODULES-8606) Add SQL Logins Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
     * [Manage the user's permissions](#manage-the-above-users-permissions)
     * [Run custom TSQL statements](#run-custom-tsql-statements)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+    * [Types](#types)
+    * [Defined Types](#defined-types)
+    * [Bolt Tasks](#bolt-tasks)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Development - Guide for contributing to the module](#development)
 
@@ -1055,6 +1058,108 @@ Default: `false`.
 > 
 > * [Reconfigure](http://msdn.microsoft.com/en-us/library/ms176069.aspx)
 > * [Server Configuration Options](http://msdn.microsoft.com/en-us/library/ms189631.aspx)
+
+### Bolt Tasks
+
+#### sqlserver::get_sql_logins
+
+This task will retrieve information about a login, or a set of logins, from the sql instances running on a given node.
+With no parameters specified it will return summary level information about all logins configured for all sql instances running on a given node or node set.
+Use the `detailed` parameter to return more detailed information including the SID's and the name of the instance a login was retrieved from.
+
+##### parameters
+
+* **instance_name**
+
+  The name of the instance to query for logins. By default, leave blank for all instances running on a node.
+  Pass the values `.`, `MSSQLSERVER`, or the node name to query just the default instance.
+  Named instances can be referred to by either the short name of the instance, or by `<COMPUTERNAME>\<INSTANCE_NAME>`.
+  This is an optional parameter which will accept a single string or array of strings as input.
+
+* **login_name**
+
+  The name of a particular login to search for, or the search pattern for a set of logins.
+  If no value is passed to this variable then all logins are returned.
+  By default any values passed to this parameter are treated like a search string.
+  Searches are done using the PowerShell `-match` operator.
+  For example, if the string `sql` is passed to this parameter, logins such as `NT SERVICE\SQLWriter`
+  and `##MS_PolicyTsqlExecutionLogin##` will be returned in the result set.
+  If the `exact_match` parameter is set to true, then only exact matches are accepted and neither of those logins would have been returned.
+  This is an optional parameter which will accept a single string or array of strings as input.
+
+* **exact_match**
+
+  Set this to true to change the behavior of the `login_name` parameter so that only logins exactly matching one of the provided login_names is returned in the result set.
+  This is an optional parameter which will accept either `true` or `false`. It's default value is false.
+
+* **detailed**
+
+  This parameter causes the task to return a more detailed level of information for each login.
+  By default the list of properties returned about each login is: `Name`,`isDisabled`,`isLocked`,`IsPasswordExpired`,`CreateDate`,`DateLastModified`.
+  Setting this parameter to true adds in the following properties: `DefaultDatabase`,`DenyWindowsLogin`,`HasAccess`,`ID`,`IsSystemObject`,`Language`,`LanguageAlias`,`,LoginType`,`MustChangePassword`,`PasswordExpirationEnabled`,`PasswordHashAlgorithm`,`PasswordPolicyEnforced`,`SQLSID`,`ADSid`,`WindowsLoginAccessType`,`UserData`,`State`,`IsDesignMode`,`InstanceName`
+
+> **A note about `SQLSID` and `ADSID`.**
+>
+> The `SQLSID` property is this module's property name for the binary representation of a SID that SQLServer keeps internally in tables like `sys.server_principals`.
+> It will look like `0x01` for accounts like `sa`, or something longer like `0x0106000000000009010000005FB6DAC7F7DB546D706711B128B5063888B01770` for other accounts.
+> This `sid` does not look like a normal `sid` you might see outside of SQLServer, but it is returned as part of the detailed information to make it easier to correlate the logins returned by this module and query results from SQLServer.
+> The `ADSID` property is a more normal looking `sid` you might get from PowerShell Active Directory query tools.
+> It is a direct translation of that `SQLSID` into the Microsoft string `sid` form and will look something like `S-1-5-80-1402415987-66678372-3059512406-1823130485-2345841878`.
+> This translation is done to make it easier to correlate SQLServer logins with AD users and detect when something like a user has been disconnected from its real AD SID.
+> If the detailed information for a login does not contain a value for the AD SID property, it means that the login is internal to SQLServer and does not have a valid AD format `sid`.
+
+#### sqlserver::set_sql_logins
+
+##### parameters
+
+* **instance_name**
+
+  The name of the instance to find the login you are setting properties on.
+  By default this parameter will use the default instance only.
+  Named instances can be referred to by either the short name of the instance, or by `<COMPUTERNAME>\<INSTANCE_NAME>`.
+  Specifying an instance name will access only that instance. To affect a login on more than one instance,
+  specify all of the required instance names as an array of values.
+  Pass the values `.`, `MSSQLSERVER`, or the node name to query only the default instance.
+  This is an optional parameter which will accept a single string or array of strings as input.
+
+* **login_name**
+
+  The name of a particular login to to set properties on.
+  By default this parameter expects an exact match. To use pattern matching see the `fuzzy_match` parameter.
+  This is an optional parameter which will accept a single string or array of strings as input.
+
+* **fuzzy_match**
+
+  Modifies the behavior of the `login_name` parameter so that the value given is a login name pattern to match.
+  Searches are done using the PowerShell `-match` operator.
+  For example, if the string `sql` is passed to the `login_name` parameter, while `fuzzy_match` is set to true, logins such as `NT SERVICE\SQLWriter`
+  and `##MS_PolicyTsqlExecutionLogin##` will be returned in the result set.
+  This is an
+   optional parameter which will accept either `true` or `false`. Its default value is false.
+
+* **enbabled**
+
+  Set this parameter to true to enable a login and set to false to disable it.
+  This is an optional boolean parameter. The return value will be an element in the json return
+  specifying that the new value for the `isDisabled` property of the login object will be either `true` or `false`.
+
+* **password**
+
+  Provide a value specifying the new password to use for a login.
+  Please note that there are possible string parsing issues when using this parameter.
+  For instance attempting to set a password `'pa$ssword#"'` may not parse correctly.
+  To get the double quote to end up in the password correctly you will need to triple quote escape the double quote,
+  like so `'pa$ssword#"""'`.
+  To ensure you password is interpreted and set correctly you may want to try to echo the password out using `bolt command run` first
+  to ensure the characters end up on the target node correctly like so, `bolt command run 'Write-Host ''This is """awesome""".'''`
+
+##### noop
+
+This task supports the `--noop` flag. The task will return json values indicating the
+actions it would have taken and the logins it would have affected without actually taking any action.
+It will not inspect and return to you what the state of a property was before taking the action.
+Use this parameter especially when using the `fuzzy_match` parameter to ensure you are affecting
+only the logins you intend to.
 
 ### Microsoft SQL Server terms
 

--- a/tasks/get_sql_logins.json
+++ b/tasks/get_sql_logins.json
@@ -1,0 +1,24 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "input_method": "powershell",
+  "description": "Retrieve information about the logins configured for a SQL Server instance.",
+  "parameters": {
+    "instance_name": {
+      "description": "The name of the SQL Instance running on the machine to connect to. Leave blank for the default instance of MSSQLSERVER",
+      "type": "Optional[Variant[Array[String], String]]"
+    },
+    "login_name": {
+      "description": "The name of a particular login to search for. You can use partial names and any pattern that will work with the PowerShell '-match' operator.",
+      "type": "Optional[Variant[Array[String], String]]"
+    },
+    "exact_match": {
+      "description": "If set to true it will force names passed to the LoginName parameter to be an exact match to a SQL Login to pass the filter.",
+      "type": "Optional[Boolean]"
+    },
+    "detailed": {
+      "description": "Return more detailed information from the server instead of the default summary information",
+      "type": "Optional[Boolean]"
+    }
+  }
+}

--- a/tasks/get_sql_logins.ps1
+++ b/tasks/get_sql_logins.ps1
@@ -1,0 +1,252 @@
+[CmdletBinding()]
+param (
+  # The name of the SQL Instance running on the node.
+  [String[]]$instance_name,
+  # The name of the SQL Login to get information about.
+  [string[]]$login_name,
+  # If true this will force the name to match a login exactly to be returned.
+  [switch]$exact_match,
+  # Return more detailed information about logins including SID's.
+  [switch]$detailed
+)
+
+$error = @{
+  _error = @{
+    msg     = ''
+    kind    = 'puppetlabs.task/task-error'
+    details = @{
+      detailedInfo = ''
+      exitcode     = 1
+    }
+  }
+}
+
+function Select-LoginName {
+  param(
+    [PSObject]$login,
+    [string[]]$namesToMatch,
+    [switch]$exact_match
+  )
+
+
+  # This function takes a single SQLServer login object and compares it against
+  # the list of names passed into the -login_name parameter of the script to
+  # determine if this is a login the user is interested in seeing. If it does
+  # not pass the filter represented by that parameter the login is discarded.
+
+  foreach ($paramLogin in $namesToMatch) {
+    if ($exact_match) {
+      if ($paramLogin -eq $login.name) {
+        Write-Output $login
+      }
+    }
+    else {
+      # Match is a regex operator, and it doesn't like the '\' in domain names.
+      if ($login.name -match [regex]::escape($paramLogin)) {
+        Write-Output $login
+      }
+    }
+  }
+}
+
+function Get-SQLInstances {
+  param(
+    [string[]]$instance_name
+  )
+
+  $instancesHolder = New-Object System.Collections.Generic.List[System.Object]
+  $stringsToReturn = New-Object System.Collections.Generic.List[System.Object]
+
+  # The default instance is referred to in its service name as MSSQLSERVER. This
+  # leads many SQLSERVER people to refer to it as such. They will also connect
+  # to it using just a '.'. None of these are its real name. Its real instance
+  # name is just the machine name. A named instances real name is the machine
+  # name a, '\', and the instance name. This little foreach ensures that we are
+  # referring to these instances by their real names so that proper filtering
+  # can be done.
+
+  foreach ($name in $instance_name) {
+    switch ($name) {
+      {($_ -eq 'MSSQLSERVER') -or ($_ -eq '.')} { [void]$instancesHolder.add($env:COMPUTERNAME) }
+      {$_ -eq $env:COMPUTERNAME} { [void]$instancesHolder.add($_) }
+      {$_ -notmatch '\\'} { [void]$instancesHolder.add("$env:COMPUTERNAME\$_") }
+      default { [void]$instancesHolder.add($name) }
+    }
+  }
+
+  $instanceStrings = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server').InstalledInstances
+
+  # The registry key does not return the real instance names. Again we must
+  # normalize these names into their real names so that comparisons can be done
+  # properly.
+
+  foreach ($string in $instanceStrings) {
+    switch ($string) {
+      'MSSQLSERVER' { $string = $env:COMPUTERNAME }
+      Default {$string = "$env:COMPUTERNAME\$string"}
+    }
+
+    if ((-not [string]::IsNullOrEmpty($instancesHolder))-and(-not [string]::IsNullOrWhiteSpace($instancesHolder))) {
+      foreach ($instance in $instancesHolder) {
+        if ($instance -eq $string) {
+          [void]$stringsToReturn.add($string)
+        }
+      }
+    }
+    else {
+      [void]$stringsToReturn.add($string)
+    }
+  }
+
+  if($stringsToReturn.count -gt 0){
+    Write-Output $stringsToReturn
+  } else {
+    throw "No instances were found by the name(s) $instance_name"
+  }
+}
+
+function Get-ServerObject {
+  param(
+    [string]$instance
+  )
+
+  [void][System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo")
+
+  Write-Output (New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList $instance)
+
+}
+
+$return = @{}
+
+#Get SQL Instances
+
+try {
+  $SQLInstances = Get-SQLInstances -instance_name $instance_name
+}
+catch {
+  $error._error.msg = 'Cannot detect SQL instance names.'
+  $error._error.details.detailedInfo = $_
+  return $error | ConvertTo-JSON
+}
+
+# Unfiltered Logins from all instances.
+$rawLogins = New-Object System.Collections.Generic.List[System.Object]
+
+foreach ($instance in $SQLInstances) {
+  try {
+    $sqlServer = Get-ServerObject -instance $instance
+  }
+  catch {
+    $error._error.msg = "Cannot connect to SQL Instance: $instance"
+    $error._error.details.detailedInfo = $_
+    return $error | ConvertTo-JSON
+  }
+
+  foreach ($item in $sqlServer.logins) {
+    # The login object doesn't return information about which instance it
+    # came from. This could be a problem on a machine running more than
+    # one instance. We'll add a property here to make sure we don't lose
+    # track of this information.
+
+    Add-Member -InputObject $item -MemberType NoteProperty -Name 'InstanceName' -Value $instance
+
+    [void]$rawLogins.add($item)
+  }
+}
+
+# Filtered logins based on the filter passed into the $login_name parameter
+$logins = New-Object System.Collections.Generic.List[System.Object]
+
+foreach ($login in $rawLogins) {
+  if ($MyInvocation.BoundParameters.ContainsKey('login_name')) {
+    [void]$logins.add((Select-LoginName -login $login -namesToMatch $login_name -exact_match:$exact_match))
+  }
+  else {
+    [void]$logins.add($login)
+  }
+}
+
+if ($detailed) {
+
+  # The SID property of the Login object contains an array of integers. This
+  # is not how SQL Server represents the login int he sys.server_principals
+  # table. The array of integers needs to be converted one by one into their
+  # Hex representation, and then joined together. This will match the value
+  # in the server_principals table and allow someone executing this script
+  # to correlate users properly.
+
+  $sidFunction = {
+    $finalSid = '0x'
+    foreach ($segment in $_.sid) {
+      $finalSid += ("{0:x2}" -f $segment).ToUpper()
+    }
+    $finalSid
+  }
+
+  # The SID column of sys.server_principals stores the binary representation
+  # of an account SID. This is not a SID that can easily be correlated to an
+  # Active Directory style SID that you can find in most other tools. This
+  # function converts SQLServer's binary sid into a SID string that people
+  # are more familiar with.
+
+  $winSidFunction = {
+    (New-Object System.Security.Principal.SecurityIdentifier($_.sid, 0)).toString()
+  }
+
+  $properties = @(
+    'Name'
+    @{N = 'CreateDate'; E = {"$($_.CreateDate)"}}
+    @{N = 'DateLastModified'; E = {"$($_.DateLastModified)"}}
+    'InstanceName'
+    'DefaultDatabase'
+    'DenyWindowsLogin'
+    'HasAccess'
+    'ID'
+    'IsDisabled'
+    'IsLocked'
+    'IsPasswordExpired'
+    'IsSystemObject'
+    'Language'
+    'LanguageAlias'
+    'LoginType'
+    'MustChangePassword'
+    'PasswordExpirationEnabled'
+    'PasswordHashAlgorithm'
+    'PasswordPolicyEnforced'
+    @{N = 'SQLSID'; E = $sidFunction}
+    @{N = 'ADSid'; E = $winSidFunction}
+    'WindowsLoginAccessType'
+    'UserData'
+    'State'
+    'IsDesignMode'
+  )
+
+  $return.logins = $logins | Select-Object $properties
+  $return | ConvertTo-JSON -Depth 99
+}
+else {
+  $properties = @(
+    'Name'
+    'isDisabled'
+    'isLocked'
+    'IsPasswordExpired'
+    @{N = 'CreateDate'; E = {"$($_.CreateDate)"}}
+    @{N = 'DateLastModified'; E = {"$($_.DateLastModified)"}}
+  )
+
+  $return.logins = $logins | Select-Object $properties
+  $return | ConvertTo-JSON -Depth 99
+}
+
+<#
+.SYNOPSIS
+  This script connects to a SQL instance running on a machine and returns
+  information about logins.
+.DESCRIPTION
+  This script will connect to SQL instances running on a machine and return
+  information about logins configured on the instance. This script only connects
+  to instances on a local server. It will always return data in JSON format.
+.PARAMETER instance_name
+  The name of the instance running on a machine that you would like to connect to.
+  Leave blank to get the default instance MSSQLSERVER.
+#>

--- a/tasks/set_sql_logins.json
+++ b/tasks/set_sql_logins.json
@@ -1,0 +1,29 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": true,
+  "input_method": "powershell",
+  "description": "Set IsDisabled, and Password properties of a SQL Login",
+  "parameters": {
+    "instance_name": {
+      "description": "Instance that has the login to be modified. Leave blank for default instance.",
+      "type": "Optional[Variant[Array[String],String]]"
+    },
+    "login_name": {
+      "description": "Name of the login to modify. Matches are exact only by default.",
+      "type": "Optional[Variant[Array[String],String]]"
+    },
+    "fuzzy_match": {
+      "description": "Allow -match operator matches on $login_name so that inputs like 'sql' will match any login with 'sql' anywhere in the name.",
+      "type": "Optional[Boolean]"
+    },
+    "enabled": {
+      "description": "Enable or disable an account. Set this to false to disable the account.",
+      "type": "Optional[Boolean]"
+    },
+    "password": {
+      "description": "The password to set for an account.",
+      "type": "Optional[String]",
+      "sensitive": true
+    }
+  }
+}

--- a/tasks/set_sql_logins.ps1
+++ b/tasks/set_sql_logins.ps1
@@ -1,0 +1,265 @@
+[CmdletBinding()]
+param (
+  # The name of the instance where the account exists.
+  [string[]]$instance_name,
+  # The login name to set
+  [string[]]$login_name,
+  # Loose matching on $login_name so 'sql' matches an login with 'sql' in the name.
+  [switch]$fuzzy_match,
+  # Enable or disable the login
+  [bool]$enabled,
+  # A new password for a login
+  [string]$password,
+  # No Op mode. Only note changes that would have been made, don't make any actual changes.
+  [bool]$_noop
+)
+
+
+function Select-LoginName {
+  param(
+    [PSObject]$login,
+    [string[]]$namesToMatch,
+    [switch]$exact_match
+  )
+
+  <#
+    This function takes a single SQLServer login object and compares it against
+    the list of names passed into the -login_name parameter of the script to
+    determine if this is a login the user is interested in seeing. If it does
+    not pass the filter represented by that parameter the login is discarded.
+  #>
+
+  foreach ($paramLogin in [string[]]$namesToMatch) {
+    if (-not $fuzzy_match) {
+      if ($paramLogin -eq $login.name) {
+        Write-Output $login
+      }
+    }
+    else {
+      # Match is a regex operator, and it doesn't like the '\' in domain names.
+      if ($login.name -match [regex]::escape($paramLogin)) {
+        Write-Output $login
+      }
+    }
+  }
+}
+
+function Get-SQLInstances {
+  param(
+    [string[]]$instance_name
+  )
+
+  $instancesHolder = New-Object System.Collections.Generic.List[System.Object]
+  $stringsToReturn = New-Object System.Collections.Generic.List[System.Object]
+
+  # The default instance is referred to in its service name as MSSQLSERVER. This
+  # leads many SQLSERVER people to refer to it as such. They will also connect
+  # to it using just a '.'. None of these are it's real name. Its real instance
+  # name is just the machine name. A named instances real name is the machine
+  # name a '\' and the instance name. This little foreach ensures that we are
+  # referring to these instances by their real names so that proper filtering
+  # can be done.
+
+  foreach ($name in $instance_name) {
+    switch ($name) {
+      {($_ -eq 'MSSQLSERVER') -or ($_ -eq '.')} { [void]$instancesHolder.add($env:COMPUTERNAME) }
+      {$_ -eq $env:COMPUTERNAME} { [void]$instancesHolder.add($_) }
+      {$_ -notmatch '\\'} { [void]$instancesHolder.add("$env:COMPUTERNAME\$_") }
+      default { [void]$instancesHolder.add($name) }
+    }
+  }
+
+  if($instancesHolder.count -eq 0){
+    [void]$instancesHolder.add($env:computername)
+  }
+
+  $instanceStrings = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server').InstalledInstances
+
+  # The registry key does not return the real instance names. Again we must
+  # normalize these names into their real names so that comparisons can be done
+  # properly.
+
+  foreach ($string in $instanceStrings) {
+    switch ($string) {
+      'MSSQLSERVER' { $string = $env:COMPUTERNAME }
+      Default {$string = "$env:COMPUTERNAME\$string"}
+    }
+
+    foreach ($instance in $instancesHolder) {
+      if ($instance -eq $string) {
+        [void]$stringsToReturn.add($string)
+      }
+    }
+  }
+
+  if($stringsToReturn.count -gt 0){
+    Write-Output $stringsToReturn
+  } else {
+    throw "No instances were found by the name(s) $instance_name"
+  }
+}
+
+function Get-ServerObject {
+  param(
+    [string]$instance
+  )
+
+  [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+
+  Write-Output (New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList $instance)
+
+}
+
+$error = @{
+  _error = @{
+    msg     = ''
+    kind    = 'puppetlabs.task/task-error'
+    details = @{
+      detailedInfo = ''
+      exitcode     = 1
+    }
+  }
+}
+
+#Get SQL Instances
+
+try {
+  $SQLInstances = Get-SQLInstances -instance_name $instance_name
+}
+catch {
+  $error._error.msg = 'Cannot detect SQL instance names.'
+  $error._error.details.detailedInfo = $_
+  return $error | ConvertTo-JSON
+}
+
+# Unfiltered Logins from all instances.
+$rawLogins = New-Object System.Collections.Generic.List[System.Object]
+
+foreach ($instance in $SQLInstances) {
+  try {
+    $sqlServer = Get-ServerObject -instance $instance
+  }
+  catch {
+    $error._error.msg = "Cannot connect to SQL Instance: $instance"
+    $error._error.details.detailedInfo = $_
+    return $error | ConvertTo-JSON
+  }
+
+  foreach ($item in $sqlServer.logins) {
+    # The login object doesn't return information about which instance it
+    # came from. This could be a problem on a machine running more than
+    # one instance. We'll add a property here to make sure we don't lose
+    # track of this information.
+
+    Add-Member -InputObject $item -MemberType NoteProperty -Name 'InstanceName' -Value $instance
+
+    [void]$rawLogins.add($item)
+  }
+}
+
+# Filtered logins based on the filter passed into the $login_name parameter
+$logins = New-Object System.Collections.Generic.List[System.Object]
+
+foreach ($login in $rawLogins) {
+  if ($MyInvocation.BoundParameters.ContainsKey('login_name')) {
+    [void]$logins.add((Select-LoginName -login $login -namesToMatch $login_name -exact_match:$exact_match))
+  }
+  else {
+    [void]$logins.add($login)
+  }
+}
+
+$setEnabled = $MyInvocation.BoundParameters.ContainsKey('enabled')
+$setPassword = $MyInvocation.BoundParameters.ContainsKey('password')
+
+$return = @{changes = @()}
+
+foreach ($login in $logins) {
+  $login_return = @{
+    login          = $login.name
+    instance       = $login.InstanceName
+    properties_set = @()
+    noop           = @()
+  }
+
+  if ($setEnabled) {
+    if ($enabled) {
+      if($_noop){
+        $login_return.noop += @{property_name = 'IsDisabled'; value = 'false'}
+      } else {
+        try {
+          $login.enable()
+          $login.alter()
+          $login_return.properties_set += @{property_name = 'IsDisabled'; value = 'false'}
+        }
+        catch {
+          $error._error.msg = "Cannot set property 'enabled' for login: $($login.InstanceName)\$($login.name)"
+          $error._error.details.detailedInfo = $_
+          return $error | ConvertTo-JSON -Depth 99
+        }
+      }
+    }
+    else {
+      if($_noop){
+        $login_return.noop += @{property_name = 'IsDisabled'; value = 'true'}
+      } else {
+        try {
+          $login.disable()
+          $login.alter()
+          $login_return.properties_set += @{property_name = 'IsDisabled'; value = 'true'}
+        }
+        catch {
+          $error._error.msg = "Cannot set property 'disabled' for login: $($login.InstanceName)\$($login.name)"
+          $error._error.details.detailedInfo = $_
+          return $error | ConvertTo-JSON -Depth 99
+        }
+      }
+    }
+  }
+
+  if ($setPassword) {
+    if($_noop){
+      $login_return.noop += @{property_name = 'password'; value = '**********'}
+    } else {
+      try {
+        $login.ChangePassword($password)
+        $login.alter()
+        $login_return.properties_set += @{property_name = 'password'; value = '**********'}
+      }
+      catch {
+        $error._error.msg = "Cannot set property 'disabled' for login: $($login.InstanceName)\$($login.name)"
+        $error._error.details.detailedInfo = $_
+        return $error | ConvertTo-Json -Depth 99
+      }
+    }
+  }
+
+  $return.changes += $login_return
+}
+
+$return | ConvertTo-JSON -Depth 99
+
+<#
+.SYNOPSIS
+  This script will set the IsDisabled parameter of a login, and it can set a
+  login password.
+.DESCRIPTION
+  This script can enable or disable logins and it can set their passwords. Pass
+  an array of login names to set these properties for multiple logins at once.
+  By default the $login_name parameter is expected to be an exact match for a
+  single login. Use the $fuzzy_match paramter to be able to enter a pattern to
+  match against multiple logins.
+.EXAMPLE
+  PS C:\>& .\set_sql_logins.ps1 -login_name sa -enabled $false -password $credential.getnetworkcredential().password
+
+  Disable the SA account on the default instance of a node, and also reset its password to a new value
+.EXAMPLE
+  PS C:\>& .\set_sql_logins.ps1 -login_name sql -fuzzy_match -instance_name test_instance -password $credential.getnetworkcredential().password
+
+  Set the password for all logins with sql in the name to a new value on the test_instance sql instance running on the node.
+.EXAMPLE
+  PS C:\>& .\set_sql_logins.ps1 -login_name sql -login_name sa -enabled $true -_noop
+
+  Run the script in no op mode to see the commands and all of the accounts the script would have affected 
+#>
+


### PR DESCRIPTION
Add a set of tasks for ad hoc management of SQL Logins. These tasks
gather information about the current state of logins on an instance and
then will allow the user to set properties of a specific user on an
instance.

Scenarios for this might be a dba that usually has the SA login disabled
might want to enable it momentarily for a specific task, and then
disable it again.

It can also be used to ensure that the state of users, like a disabled
SA account are in the state a dba expects them to be in.