### PR TITLE
Interpolate title in title to ensure uniqueness

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -107,7 +107,7 @@ define sqlserver::role(
     }
 
     if size($members) > 0 or $members_purge == true {
-      sqlserver_tsql{ "role-${role}-members":
+      sqlserver_tsql{ "${sqlserver_tsql_title}-members":
         command  => template('sqlserver/create/role/members.sql.erb'),
         onlyif   => template('sqlserver/query/role/member_exists.sql.erb'),
         instance => $instance,

--- a/spec/defines/role_spec.rb
+++ b/spec/defines/role_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
   end
 
   context 'members =>' do
-    let(:sqlserver_tsql_title) { 'role-myCustomRole-members' }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-master-myCustomRole-members' }
     describe '[test these users]' do
       let(:additional_params) { {
         :members => %w(test these users),
@@ -156,7 +156,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
     end
   end
   context 'members_purge =>' do
-    let(:sqlserver_tsql_title) { 'role-myCustomRole-members' }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-master-myCustomRole-members' }
     context 'true' do
       describe 'type => SERVER and members => []' do
         let(:additional_params) { {


### PR DESCRIPTION
Defined types should always interpolate the value of `$title` in the title of all resources in order to ensure uniqueness. This particular fix allows you to manage the same role on two different instances.