### PR TITLE
(MODULES-8677) Made resource title unique among many instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed
+
+- Cannot manage a role with the same name on two instances or two databases ([MODULES-8677](https://tickets.puppetlabs.com/browse/MODULES-8677)) (Thanks [Dylan Ratcliffe](https://github.com/dylanratcliffe))
+
 ## [2.3.0] - 2019-01-22
 
 ### Added

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -107,7 +107,7 @@ define sqlserver::role(
     }
 
     if size($members) > 0 or $members_purge == true {
-      sqlserver_tsql{ "role-${role}-members":
+      sqlserver_tsql{ "${sqlserver_tsql_title}-members":
         command  => template('sqlserver/create/role/members.sql.erb'),
         onlyif   => template('sqlserver/query/role/member_exists.sql.erb'),
         instance => $instance,

--- a/manifests/role/permissions.pp
+++ b/manifests/role/permissions.pp
@@ -53,7 +53,7 @@ define sqlserver::role::permissions (
     ##
     # Parameters required in template are _state, role, _upermissions, database, type, with_grant_option
     ##
-    sqlserver_tsql{ "role-permissions-${role}-${_state}${_grant_option}-${instance}":
+    sqlserver_tsql{ "role-permissions-${role}-${_state}${_grant_option}-${instance}-${database}":
       instance => $instance,
       command  => template('sqlserver/create/role/permissions.sql.erb'),
       onlyif   => template('sqlserver/query/role/permission_exists.sql.erb'),

--- a/spec/defines/role/permissions_spec.rb
+++ b/spec/defines/role/permissions_spec.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.join(File.dirname(__FILE__),'..'),'manif
 RSpec.describe 'sqlserver::role::permissions' do
   include_context 'manifests' do
     let(:title) { 'myTitle' }
-    let(:sqlserver_tsql_title) { 'role-permissions-myCustomRole-GRANT-MSSQLSERVER' }
+    let(:sqlserver_tsql_title) { 'role-permissions-myCustomRole-GRANT-MSSQLSERVER-master' }
     let(:params) { {
         :role => 'myCustomRole',
         :permissions => %w(INSERT UPDATE DELETE SELECT),
@@ -116,6 +116,7 @@ RSpec.describe 'sqlserver::role::permissions' do
     describe 'customDatabase' do
       let(:additional_params) { {:database => 'customDatabase'} }
       let(:should_contain_command) { ['USE [customDatabase];'] }
+      let(:sqlserver_tsql_title) { 'role-permissions-myCustomRole-GRANT-MSSQLSERVER-customDatabase' }
       it_behaves_like 'sqlserver_tsql command'
       let(:should_contain_onlyif) { ['USE [customDatabase];'] }
       it_behaves_like 'sqlserver_tsql onlyif'
@@ -135,7 +136,7 @@ RSpec.describe 'sqlserver::role::permissions' do
             :instance => instance
         } }
         it {
-          should contain_sqlserver_tsql("role-permissions-myCustomRole-GRANT-#{instance}").with_instance(instance)
+          should contain_sqlserver_tsql("role-permissions-myCustomRole-GRANT-#{instance}-master").with_instance(instance)
         }
       end
     end

--- a/spec/defines/role_spec.rb
+++ b/spec/defines/role_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
   end
 
   context 'members =>' do
-    let(:sqlserver_tsql_title) { 'role-myCustomRole-members' }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-master-myCustomRole-members' }
     describe '[test these users]' do
       let(:additional_params) { {
         :members => %w(test these users),
@@ -156,7 +156,7 @@ RSpec.describe 'sqlserver::role', :type => :define do
     end
   end
   context 'members_purge =>' do
-    let(:sqlserver_tsql_title) { 'role-myCustomRole-members' }
+    let(:sqlserver_tsql_title) { 'role-MSSQLSERVER-master-myCustomRole-members' }
     context 'true' do
       describe 'type => SERVER and members => []' do
         let(:additional_params) { {


### PR DESCRIPTION
Due to the lack of interpolating the `$title` of a defined type within the resources that it contains we have a duplication declaration under the following scenario:

*"I want to manage the members of the data_writer role on both instance 1 and instance 2".*