### PR TITLE
(MODULES-8749) Make job_name param required.

### DIFF
--- a/tasks/start_sql_agent_job.json
+++ b/tasks/start_sql_agent_job.json
@@ -9,7 +9,7 @@
     },
     "job_name": {
       "description": "The name of the job to start.",
-      "type": "Optional[Variant[Array[String],String]]"
+      "type": "Variant[Array[String],String]"
     },
     "fuzzy_match": {
       "description": "Turn the job_name parameter into a pattern to match using the PowerShell -match operator.",

--- a/tasks/start_sql_agent_job.ps1
+++ b/tasks/start_sql_agent_job.ps1
@@ -69,24 +69,8 @@ foreach ($instance in $SQLInstances) {
     }
 
     foreach ($currentJob in $sqlserver.jobserver.jobs) {
-        if ($MyInvocation.BoundParameters.ContainsKey('job_name')) {
-            if ($selectedJob = (Select-JobStrict -job $currentJob -jobsToMatch $job_name -fuzzy_match:$fuzzy_match)) {
-                [void]$jobs.add($selectedJob)
-                $jobName = $selectedJob.jobsteps[$step].name
-                if([string]::IsNullOrEmpty($jobName)){
-                    $message = `
-                    ("No job step found at index {0}. There are {1} steps in the job `"{2}`". Remember that these are zero based array indexes." `
-                    -f $step, $selectedJob.jobSteps.count, $selectedJob.name)
-                    return (Write-BoltError $message)
-                }
-                $selectedJob.start($jobName)
-                # It takes the server a little time to spin up the job. If we don't do this here
-                # then the -wait parameter may not work later.
-                Start-Sleep -Milliseconds 300
-            }
-        }
-        else {
-            [void]$jobs.add($currentJob)
+        if ($selectedJob = (Select-JobStrict -job $currentJob -jobsToMatch $job_name -fuzzy_match:$fuzzy_match)) {
+            [void]$jobs.add($selectedJob)
             $jobName = $selectedJob.jobsteps[$step].name
             if([string]::IsNullOrEmpty($jobName)){
                 $message = `
@@ -95,6 +79,8 @@ foreach ($instance in $SQLInstances) {
                 return (Write-BoltError $message)
             }
             $selectedJob.start($jobName)
+            # It takes the server a little time to spin up the job. If we don't do this here
+            # then the -wait parameter may not work later.
             Start-Sleep -Milliseconds 300
         }
     }


### PR DESCRIPTION
Prior to this change, even though the job_name param is defined as
required by the PowerShell script that powers the task, the json file
that describes the task defines that parameter to Bolt as Optional.

This causes the task to hang if the task is invoked with no job_name
parameter. This change updates the json so that Bolt understands the
param is required, and removes an unnecessary conditional check to
to ensure the paramter is present, as both platforms already ensure
it. The else block in that check also had code that should never run
in this task.