### PR TITLE
(MAINT) Increase timeout interval

### DIFF
--- a/tasks/start_sql_agent_job.ps1
+++ b/tasks/start_sql_agent_job.ps1
@@ -79,11 +79,12 @@ foreach ($instance in $SQLInstances) {
                 return (Write-BoltError $message)
             }
             $selectedJob.start($jobName)
-            # It takes the server a little time to spin up the job. If we don't do this here
-            # then the -wait parameter may not work later.
-            Start-Sleep -Milliseconds 300
         }
     }
+
+    # It takes the server a little time to spin up the job. If we don't do this here
+    # then the -wait parameter may not work later.
+    Start-Sleep -Seconds 1
 }
 
 do {
@@ -96,6 +97,7 @@ do {
         }
         [void]$finishedJobs.add((New-CustomJobObject -job $job))
     }
+    Start-Sleep -Milliseconds 300
 } while ($wait -and !$done)
 
 $return.jobs = $finishedJobs


### PR DESCRIPTION
The wait parameter in the start_sql_agent_job depends on a sleep
interval that waits long enough for the agent to spool up a job and get
it running.

In testing it appears that some agent jobs are not spinning up fast
enough, causing the wait parameter to have no effect. This change
increased the timeout so that the wait parameter has time to see the
job starting to execute and then wait for it to complete.