### PR TITLE
(MODULES-7553) Add Example Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,21 @@ sqlserver_tsql {'check advanced sp_configure':
   value => 2048
 }
 ```
+*Note:*
+$facts['hostnane'] is only suitable for building login names for local machine logins. For building domain logins you will need the domain name instead. $facts['domain'] returns the full domain name which will usually not be what you need. Try instead:
+
+```puppet
+$netbios_name = split($facts['domain'],'\.')[0]
+
+$dba_group_netbios_name = "${netbios_name}\\DB Administrators"
+
+sqlserver::role { 'sysadmin':
+  ensure   => 'present',
+  instance => 'MSSQLSERVER',
+  type     => 'SERVER',
+  members  => [$dba_group_netbios_name, $facts['id']],
+}
+```
 
 ## Reference
 


### PR DESCRIPTION
A user trying to follow our advanced example ran into an issue. The
example as written is only suitable for setups that are using local
accounts, not domain accounts. They also found that the Facter fact
`domain` returns the FQDN of the domain, which is not suitable for
contsructing user names in the `netbiosname\username` format.

This change adds a clarification to the example that the example is only
usable when using local group, and given that there is no `netbiosname`
fact available, provides a suggestion for one way to work around the
issue.