### PR TITLE
(MODULES-6904) Restart SQL Server Service with Dependent Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - Add DQC to sqlserver_features feature attribute ([MODULES-8600](https://tickets.puppetlabs.com/browse/MODULES-8600))
 - Fix sqlserver_instances fact fails when registry contains uninstalled instances ([MODULES-8439](https://tickets.puppetlabs.com/browse/MODULES-8439))
+- Switch to using PowerShell `Restart-Service .. -Force` to restart the SQLServer service in `sqlserver::sp_configure` ([MODULES-6904](https://tickets.puppetlabs.com/browse/MODULES-6904))
 
 ## [2.5.0] - 2019-03-26
 

--- a/manifests/sp_configure.pp
+++ b/manifests/sp_configure.pp
@@ -41,10 +41,8 @@ define sqlserver::sp_configure (
     default => "MSSQL\$${instance}"
   }
 
-  ensure_resource('service',$service_name)
-
   if $restart {
-    Sqlserver_tsql["sp_configure-${instance}-${config_name}"] ~> Service[$service_name]
+    Sqlserver_tsql["sp_configure-${instance}-${config_name}"] ~> Exec["restart-service-${service_name}"]
   }
 
   sqlserver_tsql{ "sp_configure-${instance}-${config_name}":
@@ -52,5 +50,12 @@ define sqlserver::sp_configure (
     command  => template('sqlserver/create/sp_configure.sql.erb'),
     onlyif   => template('sqlserver/query/sp_configure.sql.erb'),
     require  => Sqlserver::Config[$instance]
+  }
+
+  exec{"restart-service-${service_name}":
+    command     => template('sqlserver/restart_service.ps1.erb'),
+    provider    => powershell,
+    logoutput   => true,
+    refreshonly => true,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 1.0.1"
     }
   ],
   "operatingsystem_support": [

--- a/spec/defines/sp_configure_spec.rb
+++ b/spec/defines/sp_configure_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'sqlserver::sp_configure', :type => :define do
 
   describe 'service' do
     it 'should be defined' do
-      should contain_service('MSSQLSERVER')
+      should contain_exec('restart-service-MSSQLSERVER').with_refreshonly(true)
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -85,6 +85,7 @@ unless ENV['MODULE_provision'] == 'no'
 
     # Install sqlserver dependencies.
     on(agent, puppet('module install puppetlabs-stdlib'))
+    on(agent, puppet('module install puppetlabs-powershell'))
 
     # Mount windows 2012R2 ISO to allow install of .NET 3.5 Windows Feature
     iso_opts = {
@@ -102,6 +103,7 @@ unless ENV['MODULE_provision'] == 'no'
   hosts_as("master").each do |host|
     # Install sqlserver dependencies.
     on(host, puppet('module install puppetlabs-stdlib'))
+    on(host, puppet('module install puppetlabs-powershell'))
 
     # Install sqlserver module from local source.
     # See FM-5062 for more details.

--- a/templates/restart_service.ps1.erb
+++ b/templates/restart_service.ps1.erb
@@ -1,0 +1,2 @@
+Restart-Service -Name '<%= @service_name %>' -Force
+


### PR DESCRIPTION
Prviously, the sp_configure.pp file would attempt to use the builtin
service resource to restart the MSSQLServer service if a configuration
change was made. This attempt would fail if there was a dependent
service such as the SQL Agent service, which is extremely common.

This change implements an extremely small PowerShell script instead to
force restart the MSSQLSERVER service, even if there are dependent
services.

In testing this resulted in the Agent service going down and then
coming back up as expected.