### PR TITLE
(MODULES-9912) ERB Template Errors

### DIFF
--- a/manifests/role/permissions.pp
+++ b/manifests/role/permissions.pp
@@ -45,7 +45,6 @@ define sqlserver::role::permissions (
     sqlserver_validate_instance_name($instance)
     $_state = upcase($state)
 
-    $_upermissions = upcase($permissions)
     $_grant_option = $with_grant_option ? {
       true => '-WITH_GRANT_OPTION',
       false => '',

--- a/templates/create/login/permission.sql.erb
+++ b/templates/create/login/permission.sql.erb
@@ -1,7 +1,7 @@
 USE [master];
 DECLARE @perm_state varchar(250), @error_msg varchar(250), @permission varchar(250);
-<% @permissions.each do |permission|
-    permission.upcase!
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
 %>
 SET @permission = '<%= permission %>'
 BEGIN

--- a/templates/create/role/permissions.sql.erb
+++ b/templates/create/role/permissions.sql.erb
@@ -1,15 +1,15 @@
 USE [<%= @database %>];
 <%= scope.function_template(['sqlserver/snippets/role/declare_and_set_variables.sql.erb']) -%>
 
- <%- @_upermissions.each do |permission|
-  permission.upcase!
- -%>
- SET @permission = '<%= permission %>';
- <% if @with_grant_option == false %>
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
+%>
+SET @permission = '<%= permission %>';
+<% if @with_grant_option == false %>
     IF 'GRANT_WITH_GRANT_OPTION' = <%= scope.function_template(['sqlserver/snippets/principal/permission/get_perm_state.sql.erb']) -%>
     BEGIN
         REVOKE GRANT OPTION FOR <%= permission %> TO [<%= @role %>] CASCADE;
     END
     <% end -%>
     <%= @_state %> <%= permission %> TO [<%= @role %>]<% if @with_grant_option == true %> WITH GRANT OPTION<% end %>;
- <% end %>
+<% end %>

--- a/templates/create/user/permission.sql.erb
+++ b/templates/create/user/permission.sql.erb
@@ -1,8 +1,8 @@
- USE [<%= @database %>];
- DECLARE @perm_state varchar(250), @error_msg varchar(250), @permission varchar(250);
- <% @permissions.each do |permission|
-  permission.upcase!
- %>
+USE [<%= @database %>];
+DECLARE @perm_state varchar(250), @error_msg varchar(250), @permission varchar(250);
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
+%>
 SET @permission = '<%= permission %>'
 BEGIN
     <% if @with_grant_option == false %>

--- a/templates/query/login/permission_exists.sql.erb
+++ b/templates/query/login/permission_exists.sql.erb
@@ -1,8 +1,8 @@
 USE [master];
 DECLARE @perm_state varchar(250), @error_msg varchar(250), @permission varchar(250);
- <% @permissions.each do |permission|
-  permission.upcase!
- %>
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
+%>
 SET @permission = '<%= permission %>'
 <%= scope.function_template(['sqlserver/snippets/login/permission/exists.sql.erb']) %>
 <% end %>

--- a/templates/query/role/permission_exists.sql.erb
+++ b/templates/query/role/permission_exists.sql.erb
@@ -1,8 +1,9 @@
 USE [<%= @database %>];
 <%= scope.function_template(['sqlserver/snippets/role/declare_and_set_variables.sql.erb']) -%>
 
-<% @permissions.each do |permission|
-    permission.upcase! -%>
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
+%>
 SET @permission = '<%= permission %>';
 <%= scope.function_template(['sqlserver/snippets/principal/permission/exists.sql.erb']) -%>
 <% end -%>

--- a/templates/query/user/permission_exists.sql.erb
+++ b/templates/query/user/permission_exists.sql.erb
@@ -1,8 +1,9 @@
 USE [<%= @database %>];
 
 DECLARE @perm_state varchar(250), @error_msg varchar(250), @permission varchar(250);
-<% @permissions.each do |permission|
-permission.upcase! %>
+<% @permissions.each do |requested_permission|
+    permission = requested_permission.upcase
+%>
 SET @permission = '<%= permission %>'
 <%= scope.function_template(['sqlserver/snippets/user/permission/exists.sql.erb']) %>
 <% end %>


### PR DESCRIPTION
Prior to this change, some ERB templates would cause jruby errors
on the master during catalog compilation. The templates contained code
that would attempt to modify the value of a frozen string.

This change modifies the template code to ensure that no frozen string
values are attempted to be modified.

It also makes slight fixes to the syntax in the templates to ensure that
each instance of this pattern is written more consistantly.