### PR TITLE
(maint) Update .sync.yml for Rubocop fixes

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,11 @@
   delete: true
 ".rubocop.yml":
   include_todos: true
+  profiles:
+    strict:
+      configs:
+        Metrics/LineLength:
+          Max: 300
 ".travis.yml":
   simplecov: true
 appveyor.yml:
@@ -40,5 +45,5 @@ spec/spec_helper.rb:
   coverage_report: true
   spec_overrides:
   - def regexp_matches(available_parameters)
-  - "    match(available_parameters)"
+  - "  match(available_parameters)"
   - end

--- a/metadata.json
+++ b/metadata.json
@@ -49,5 +49,5 @@
   ],
   "pdk-version": "1.14.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-gfaf9e8b"
+  "template-ref": "heads/master-0-g643529a"
 }


### PR DESCRIPTION
The `.sync.yml` was not updated to maintain a number of Rubocop fixes made during this PR: https://github.com/puppetlabs/puppetlabs-sqlserver/pull/326

This ensures that a `pdk update` will not overwrite those changes and cause subsequent PRs to fail Rubocop checks.