### PR TITLE
(maint) Update test checking SSMS feature compatibility

### DIFF
--- a/spec/acceptance/z_last_sqlserver_features_spec.rb
+++ b/spec/acceptance/z_last_sqlserver_features_spec.rb
@@ -82,7 +82,7 @@ describe 'sqlserver_features', node: host do
   end
 
   context 'can remove independent feature' do
-    if sql_version == '2016'
+    if sql_version.to_i >= 2016
       all_possible_features = ['BC', 'Conn', 'SDK', 'IS', 'MDS', 'DQC']
       features = ['BC', 'Conn', 'SDK', 'IS', 'MDS', 'DQC']
     else


### PR DESCRIPTION
SSMS is installed separately starting with SQL Server 2016. Update
a test to omit SSMS from feature support checks from 2016 and
newer, rather than only 2016. See also MODULES-6585.