### PR TITLE
(FM-8879) Handle T-SQL Errors Properly

### DIFF
--- a/lib/puppet/property/sqlserver_tsql.rb
+++ b/lib/puppet/property/sqlserver_tsql.rb
@@ -6,6 +6,7 @@ class Puppet::Property::SqlserverTsql < Puppet::Property # rubocop:disable Style
     quoted_value = value.gsub('\'', '\'\'')
     erb_template = <<-TEMPLATE
 BEGIN TRY
+    SET NOCOUNT ON
     DECLARE @sql_text as NVARCHAR(max);
     SET @sql_text = N'#{quoted_value}'
     EXECUTE sp_executesql @sql_text;

--- a/spec/unit/puppet/property/tsql_spec.rb
+++ b/spec/unit/puppet/property/tsql_spec.rb
@@ -13,8 +13,8 @@ describe 'tsql' do
   it 'munges value to have begin and end try' do
     @node[:command] = 'function foo'
     @node[:onlyif] = 'exec bar'
-    expect(@node[:onlyif]).to match(%r{BEGIN TRY\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'exec bar'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY})
-    expect(@node[:command]).to match(%r{BEGIN TRY\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'function foo'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY})
+    expect(@node[:onlyif]).to match(%r{BEGIN TRY\n\s+SET NOCOUNT ON\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'exec bar'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY})
+    expect(@node[:command]).to match(%r{BEGIN TRY\n\s+SET NOCOUNT ON\n\s+DECLARE @sql_text as NVARCHAR\(max\);\n\s+SET @sql_text = N'function foo'\n\s+EXECUTE sp_executesql @sql_text;\nEND TRY})
   end
 
   it 'properlies escape single quotes in queries' do


### PR DESCRIPTION
The previous commit that improved T-SQL error handling was incomplete.
That commit (9b8a0fe9bbbe0699b6626f92ac6f9dc4ddad9584) was not able to
overcome an important issue.

The issue was that if there was a successfull row insert into a table
the `Errors` collection of the ADODB.Connection would be empty, even
if an error was deliberately thrown using the `THROW` keyword.

It turns out that the successfull row insert was causing a text return
value, and it's a known issue that if values are returned to the object
that the Errors collection will be empty.

We know now that turning `SET NOCOUNT ON` in the beginning of the query
will suppress that text status message and allow more errors to be
properly detected in the ADODB.Connect object, and handled properly
in the module's `onlyif` clause.