### PR TITLE
(MODULES-10825) - Dotnet installation fix

### DIFF
--- a/lib/puppet/provider/sqlserver_features/mssql.rb
+++ b/lib/puppet/provider/sqlserver_features/mssql.rb
@@ -127,8 +127,7 @@ Puppet::Type.type(:sqlserver_features).provide(:mssql, parent: Puppet::Provider:
       instance_version = PuppetX::Sqlserver::ServerHelper.sql_version_from_install_source(@resource[:source])
       Puppet.debug("Installation source detected as version #{instance_version}") unless instance_version.nil?
 
-      install_net_35
-      (@resource[:windows_feature_source]) unless [SQL_2016, SQL_2017, SQL_2019].include? instance_version
+      install_net_35(@resource[:windows_feature_source]) unless [SQL_2016, SQL_2017, SQL_2019].include? instance_version
 
       debug "Installing features #{@resource[:features]}"
       add_features(@resource[:features])


### PR DESCRIPTION
Seems as if the check on whether Dotnet installation is necessary and the feature source pass where accidentally separated from the install method call.