### PR TITLE
(MODULES-5472) Login values can now be passed as sensitive strings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,8 +6,10 @@
 #   The instance name you want to manage.  Defaults to the $title when not defined explicitly.
 # @param admin_user
 #   Only required for SQL_LOGIN type. A user/login who has sysadmin rights on the server
+#   Can be passed as a sensitive value
 # @param admin_pass
 #   Only required for SQL_LOGIN type. The password in order to access the server to be managed.
+#   Can be passed as a sensitive value
 # @param admin_login_type
 #   The type of account use to configure the server.  Valid values are SQL_LOGIN and WINDOWS_LOGIN, with a default of SQL_LOGIN
 #   The SQL_LOGIN requires the admin_user and admin_pass to be set
@@ -20,8 +22,8 @@
 #   }
 #
 define sqlserver::config (
-  Optional[String] $admin_user = '',
-  Optional[String] $admin_pass = '',
+  Optional[Variant[Sensitive[String], String]] $admin_user = '',
+  Optional[Variant[Sensitive[String], String]] $admin_pass = '',
   Enum['SQL_LOGIN', 'WINDOWS_LOGIN'] $admin_login_type = 'SQL_LOGIN',
   String[1,16] $instance_name = $title,
 ) {

--- a/manifests/login.pp
+++ b/manifests/login.pp
@@ -17,6 +17,7 @@
 #
 # @param password
 #   Plain text password. Only applicable when Login_Type = 'SQL_LOGIN'.
+#   Can be passed through as a sensitive value.
 #
 # @param svrroles
 #   A hash of preinstalled server roles that you want assigned to this login.
@@ -55,7 +56,7 @@ define sqlserver::login (
   String[1,16] $instance = 'MSSQLSERVER',
   Enum['SQL_LOGIN', 'WINDOWS_LOGIN'] $login_type = 'SQL_LOGIN',
   Enum['present', 'absent'] $ensure = 'present',
-  Optional[String] $password = undef,
+  Optional[Variant[Sensitive[String], String]] $password = undef,
   Optional[Hash] $svrroles = { },
   String $default_database = 'master',
   String $default_language = 'us_english',


### PR DESCRIPTION
admin_user, admin_pass and password can now be passed as sensitive strings in order to prevent them from being leaked within the logs.