### PR TITLE
(CAT-136) Update dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 8.0.0"
+      "version_requirement": ">= 4.13.1 < 9.0.0"
     },
     {
       "name": "puppetlabs/powershell",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 6.0.0"
+      "version_requirement": ">= 1.0.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this release, we were preparing for a major release in several
modules, including powershell and apt. This meant that some modules that
use them as a dependency might need their metadata.json file updated to
keep working properly.

This update aims to correctly update the dependecies of the sqlserver
module so that it can keep working properly with our latest release of
our powershell module.