### PR TITLE
(CONT-370) Reinstate lost sqlserver documentation on feature & tool deprecations

### DIFF
--- a/lib/puppet/type/sqlserver_features.rb
+++ b/lib/puppet/type/sqlserver_features.rb
@@ -35,8 +35,10 @@ Puppet::Type.newtype(:sqlserver_features) do
   end
 
   newproperty(:features, array_matching: :all) do
-    desc 'Specifies features to install, uninstall, or upgrade. The list of top-level features include
-         BC, Conn, SSMS, ADV_SSMS, SDK, IS and MDS.'
+    desc "Specifies features to install, uninstall, or upgrade. The list of top-level features include
+          BC, Conn, SSMS, ADV_SSMS, SDK, IS and MDS.
+
+          The 'Tools' feature is deprecated.  Instead specify 'BC', 'SSMS', 'ADV_SSMS', 'Conn', and 'SDK' explicitly."
     newvalues(:Tools, :BC, :Conn, :SSMS, :ADV_SSMS, :SDK, :IS, :MDS, :BOL, :DREPLAY_CTLR, :DREPLAY_CLT, :DQC)
     munge do |value|
       if PuppetX::Sqlserver::ServerHelper.is_super_feature(value)

--- a/lib/puppet/type/sqlserver_instance.rb
+++ b/lib/puppet/type/sqlserver_instance.rb
@@ -25,8 +25,10 @@ Puppet::Type.newtype(:sqlserver_instance) do
   end
 
   newproperty(:features, array_matching: :all) do
-    desc 'Specifies features to install, uninstall, or upgrade. The list of top-level features include
-          SQLEngine, Replication, FullText, DQ AS, and RS.'
+    desc "Specifies features to install, uninstall, or upgrade. The list of top-level features include
+          SQLEngine, Replication, FullText, DQ AS, and RS.
+
+          The 'SQL' feature is deprecated.  Instead specify 'DQ', 'FullText', 'Replication', and 'SQLEngine' explicitly."
     newvalues(:SQL, :SQLEngine, :Replication, :FullText, :DQ, :AS, :RS, :POLYBASE, :ADVANCEDANALYTICS)
     munge do |value|
       if PuppetX::Sqlserver::ServerHelper.is_super_feature(value)


### PR DESCRIPTION
Prior to this commit, using puppetlabs-sqlserver with deprecated features/tools would raise a deprecation warning messages in puppet agent runs, although the documentation says the deprecated variable is valid. This is due to a mistake in a puppet-strings run which excluded part of the documentation regarding this issue. This commit reinstate this documentation to avoid future confusion.