### PR TITLE
(MAINT) - Remove deprecated 'has_key'

### DIFF
--- a/manifests/login.pp
+++ b/manifests/login.pp
@@ -92,25 +92,25 @@ define sqlserver::login (
       instance  => $instance,
       require   => Sqlserver_tsql["login-${instance}-${login}"],
     }
-    if has_key($_upermissions, 'GRANT') and $_upermissions['GRANT'] =~ Array {
+    if 'GRANT' in $_upermissions and $_upermissions['GRANT'] =~ Array {
       sqlserver::login::permissions { "Sqlserver::Login[${title}]-GRANT-${login}":
         state       => 'GRANT',
         permissions => $_upermissions['GRANT'],
       }
     }
-    if has_key($_upermissions, 'DENY') and $_upermissions['DENY'] =~ Array {
+    if 'DENY' in $_upermissions and $_upermissions['DENY'] =~ Array {
       sqlserver::login::permissions { "Sqlserver::Login[${title}]-DENY-${login}":
         state       => 'DENY',
         permissions => $_upermissions['DENY'],
       }
     }
-    if has_key($_upermissions, 'REVOKE') and $_upermissions['REVOKE'] =~ Array {
+    if 'REVOKE' in $_upermissions and $_upermissions['REVOKE'] =~ Array {
       sqlserver::login::permissions { "Sqlserver::Login[${title}]-REVOKE-${login}":
         state       => 'REVOKE',
         permissions => $_upermissions['REVOKE'],
       }
     }
-    if has_key($_upermissions, 'GRANT_WITH_OPTION') and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
+    if 'GRANT_WITH_OPTION' in $_upermissions and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
       sqlserver::login::permissions { "Sqlserver::Login[${title}]-GRANT-WITH_GRANT_OPTION-${login}":
         state             => 'GRANT',
         with_grant_option => true,

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -79,25 +79,25 @@ define sqlserver::role (
       type     => $type,
       require  => Sqlserver_tsql[$sqlserver_tsql_title],
     }
-    if has_key($_upermissions, 'GRANT') and $_upermissions['GRANT'] =~ Array {
+    if 'GRANT' in $_upermissions and $_upermissions['GRANT'] =~ Array {
       sqlserver::role::permissions { "Sqlserver::Role[${title}]-GRANT-${role}":
         state       => 'GRANT',
         permissions => $_upermissions['GRANT'],
       }
     }
-    if has_key($_upermissions, 'DENY') and $_upermissions['DENY'] =~ Array {
+    if 'DENY' in $_upermissions and $_upermissions['DENY'] =~ Array {
       sqlserver::role::permissions { "Sqlserver::Role[${title}]-DENY-${role}":
         state       => 'DENY',
         permissions => $_upermissions['DENY'],
       }
     }
-    if has_key($_upermissions, 'REVOKE') and $_upermissions['REVOKE'] =~ Array {
+    if 'REVOKE' in $_upermissions and $_upermissions['REVOKE'] =~ Array {
       sqlserver::role::permissions { "Sqlserver::Role[${title}]-REVOKE-${role}":
         state       => 'REVOKE',
         permissions => $_upermissions['REVOKE'],
       }
     }
-    if has_key($_upermissions, 'GRANT_WITH_OPTION') and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
+    if 'GRANT_WITH_OPTION' in $_upermissions and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
       sqlserver::role::permissions { "Sqlserver::Role[${title}]-GRANT-WITH_GRANT_OPTION-${role}":
         state             => 'GRANT',
         with_grant_option => true,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -79,25 +79,25 @@ define sqlserver::user (
       instance  => $instance,
       require   => Sqlserver_tsql["user-${instance}-${database}-${user}"],
     }
-    if has_key($_upermissions, 'GRANT') and $_upermissions['GRANT'] =~ Array {
+    if 'GRANT' in $_upermissions and $_upermissions['GRANT'] =~ Array {
       sqlserver::user::permissions { "Sqlserver::User[${title}]-GRANT-${user}":
         state       => 'GRANT',
         permissions => $_upermissions['GRANT'],
       }
     }
-    if has_key($_upermissions, 'DENY') and $_upermissions['DENY'] =~ Array {
+    if 'DENY' in $_upermissions and $_upermissions['DENY'] =~ Array {
       sqlserver::user::permissions { "Sqlserver::User[${title}]-DENY-${user}":
         state       => 'DENY',
         permissions => $_upermissions['DENY'],
       }
     }
-    if has_key($_upermissions, 'REVOKE') and $_upermissions['REVOKE'] =~ Array {
+    if 'REVOKE' in $_upermissions and $_upermissions['REVOKE'] =~ Array {
       sqlserver::user::permissions { "Sqlserver::User[${title}]-REVOKE-${user}":
         state       => 'REVOKE',
         permissions => $_upermissions['REVOKE'],
       }
     }
-    if has_key($_upermissions, 'GRANT_WITH_OPTION') and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
+    if 'GRANT_WITH_OPTION' in $_upermissions and $_upermissions['GRANT_WITH_OPTION'] =~ Array {
       sqlserver::user::permissions { "Sqlserver::User[${title}]-GRANT-WITH_GRANT_OPTION-${user}":
         state             => 'GRANT',
         with_grant_option => true,


### PR DESCRIPTION
Replaces instances of the deprecated 'has_key' function removed in https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319