### PR TITLE
(CONT-985) Address deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Prior to this commit, there were deprecation warnings in the github action workflows regarding use of checkout@v2. This commit uses v3.