### PR TITLE
(maint) - update trigger in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: "ci"
 
 on:
-  pull_request:
-    branches:
-      - "main"
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
Necessary change to workflow that ensures that the CI can still run on forked PRs and supply secrets. 

## Additional Context
See https://github.com/puppetlabs/puppetlabs-lvm/pull/302

**Note the tests will not run until merged**

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)