### PR TITLE
CAT-1208 : Fix CI to run workflow againt PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
 
     steps:
 
-    - name: Checkout Source
+    - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -61,8 +63,10 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main' 
 
     steps:
-    - name: Checkout Source
+    - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,8 +21,10 @@ jobs:
 
     steps:
 
-    - name: Checkout Source
+    - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -60,8 +62,10 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main' 
 
     steps:
-    - name: Checkout Source
+    - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
Earlier acceptance tests were running always against the main branch irrespective of the PR branch or any code changes.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)