### PR TITLE
(MODULES-11567): Enhance validation methods to resolve deferred values for validation in sqlserver_instance type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -69,10 +69,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.1"
         bundler-cache: true
 
     - name: Print bundle environment
@@ -93,7 +93,7 @@ jobs:
       run: |
         bundle exec rake 'litmus:install_module'
 
-    - name: Authenitcate with GCP
+    - name: Authenticate with GCP
       run: |
         echo '${{ secrets.GCP_CONNECTION }}' >> creds.json
         bundle exec bolt file upload creds.json C:\\creds.json --targets ssh_nodes --inventoryfile spec/fixtures/litmus_inventory.yaml

--- a/spec/unit/puppet/type/sqlserver_instance_spec.rb
+++ b/spec/unit/puppet/type/sqlserver_instance_spec.rb
@@ -84,4 +84,28 @@ RSpec.describe Puppet::Type.type(:sqlserver_instance) do
       end
     end
   end
+
+  describe 'agt_svc_account' do
+    context 'when value is a deferred value' do
+      let(:args) do
+        basic_args.merge({ agt_svc_account: Puppet::Pops::Evaluator::DeferredValue.new(proc { 'nexus\\travis' }) })
+      end
+
+      it 'validate' do
+        subject = Puppet::Type.type(:sqlserver_instance).new(args)
+        expect(subject.resolve_deferred_value(subject[:agt_svc_account])).to eq('nexus\\travis')
+      end
+    end
+
+    context 'when value is not a deferred value' do
+      let(:args) do
+        basic_args.merge({ agt_svc_account: 'nexus\\travis' })
+      end
+
+      it 'validate' do
+        subject = Puppet::Type.type(:sqlserver_instance).new(args)
+        expect(subject.resolve_deferred_value(subject[:agt_svc_account])).to eq('nexus\\travis')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
**Improve validation logic in the sqlserver_instance type to handle deferred values**

In the current implementation, when the `preprocess_deferred` flag is set to `true`, Puppet resolves deferred values before validation, allowing `sqlserver_instance` to validate parameters successfully.

However, when `preprocess_deferred` is `false`, deferred values remain unresolved at the time of validation, causing it to fail. To address this issue, we’ve updated the validation logic to explicitly resolve deferred values during validation, ensuring the module functions correctly regardless of the `preprocess_deferred` setting.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)