### PR TITLE
ci(MODULES-11557): add Twingate setup step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main' 
 
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,11 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main' 
 
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Adds the Twingate installation step in `.github/workflows/...` using `twingate/github-action@v1`. The action uses the `${{ secrets.TWINGATE_KEY }}` to establish secure access to internal resources.

This enables the workflow to access protected infrastructure during CI runs.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)