### PR TITLE
(maint) Bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
       if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -91,7 +91,7 @@ jobs:
         nslookup artifactory.delivery.puppetlabs.net
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
## Summary
- `actions/checkout@v3` uses the deprecated Node 16 runtime and logs warnings on every CI run.
- Bumps both occurrences in `ci.yml` to `@v4` (Node 20). Already the fleet standard in `puppetlabs-lvm`.
- No behavior change for these workflows.

## Test plan
- [x] CI passes on this PR (checkout works on both the `setup_matrix` and `Acceptance` jobs)
