### PR TITLE
(MODULES-11838) Update link to Puppet modules contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Puppet modules
 
-Check out our [Contributing to Supported Modules Blog Post](https://puppetlabs.github.io/iac/docs/contributing_to_a_module.html) to find all the information that you will need.
+Check out our [Contributing to Puppet modules docs](https://help.puppet.com/core/current/Content/PuppetCore/contributing.htm) to find all the information that you will need.


### PR DESCRIPTION
## Summary

Existing link in `CONTRIBUTING.md` points to a missing GitHub doc — `https://puppetlabs.github.io/iac/docs/contributing_to_a_module.html` returns **HTTP 404**.

This PR updates the link to the live doc on `help.puppet.com`. Same fix as [puppetlabs/puppetlabs-stdlib#1468](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1468) — sqlserver is the only supported puppetlabs module where the broken link had not yet been propagated.

Jira: [MODULES-11838](https://perforce.atlassian.net/browse/MODULES-11838)

## Checklist

- [N/A] 🟢 Spec tests.
- [N/A] 🟢 Acceptance tests.
- [x] Manually verified — new URL returns HTTP 200.